### PR TITLE
LPS-71050

### DIFF
--- a/journal-api/build.gradle
+++ b/journal-api/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
 	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
-	provided group: "com.liferay", name: "com.liferay.dynamic.data.mapping.api", version: "3.0.0"
+	provided group: "com.liferay", name: "com.liferay.dynamic.data.mapping.api", version: "3.6.0-20170303.140213-11"
 	provided group: "com.liferay", name: "com.liferay.osgi.util", version: "3.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.search", version: "3.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"

--- a/journal-api/src/main/java/com/liferay/journal/model/JournalArticleLocalizationModel.java
+++ b/journal-api/src/main/java/com/liferay/journal/model/JournalArticleLocalizationModel.java
@@ -93,16 +93,16 @@ public interface JournalArticleLocalizationModel extends BaseModel<JournalArticl
 	public void setCompanyId(long companyId);
 
 	/**
-	 * Returns the article p k of this journal article localization.
+	 * Returns the article pk of this journal article localization.
 	 *
-	 * @return the article p k of this journal article localization
+	 * @return the article pk of this journal article localization
 	 */
 	public long getArticlePK();
 
 	/**
-	 * Sets the article p k of this journal article localization.
+	 * Sets the article pk of this journal article localization.
 	 *
-	 * @param articlePK the article p k of this journal article localization
+	 * @param articlePK the article pk of this journal article localization
 	 */
 	public void setArticlePK(long articlePK);
 

--- a/journal-api/src/main/java/com/liferay/journal/model/JournalArticleLocalizationWrapper.java
+++ b/journal-api/src/main/java/com/liferay/journal/model/JournalArticleLocalizationWrapper.java
@@ -215,9 +215,9 @@ public class JournalArticleLocalizationWrapper
 	}
 
 	/**
-	* Returns the article p k of this journal article localization.
+	* Returns the article pk of this journal article localization.
 	*
-	* @return the article p k of this journal article localization
+	* @return the article pk of this journal article localization
 	*/
 	@Override
 	public long getArticlePK() {
@@ -255,9 +255,9 @@ public class JournalArticleLocalizationWrapper
 	}
 
 	/**
-	* Sets the article p k of this journal article localization.
+	* Sets the article pk of this journal article localization.
 	*
-	* @param articlePK the article p k of this journal article localization
+	* @param articlePK the article pk of this journal article localization
 	*/
 	@Override
 	public void setArticlePK(long articlePK) {

--- a/journal-api/src/main/java/com/liferay/journal/model/JournalArticleModel.java
+++ b/journal-api/src/main/java/com/liferay/journal/model/JournalArticleModel.java
@@ -278,17 +278,17 @@ public interface JournalArticleModel extends AttachedModel,
 	public void setClassNameId(long classNameId);
 
 	/**
-	 * Returns the class p k of this journal article.
+	 * Returns the class pk of this journal article.
 	 *
-	 * @return the class p k of this journal article
+	 * @return the class pk of this journal article
 	 */
 	@Override
 	public long getClassPK();
 
 	/**
-	 * Sets the class p k of this journal article.
+	 * Sets the class pk of this journal article.
 	 *
-	 * @param classPK the class p k of this journal article
+	 * @param classPK the class pk of this journal article
 	 */
 	@Override
 	public void setClassPK(long classPK);
@@ -368,32 +368,32 @@ public interface JournalArticleModel extends AttachedModel,
 	public void setContent(String content);
 
 	/**
-	 * Returns the d d m structure key of this journal article.
+	 * Returns the ddm structure key of this journal article.
 	 *
-	 * @return the d d m structure key of this journal article
+	 * @return the ddm structure key of this journal article
 	 */
 	@AutoEscape
 	public String getDDMStructureKey();
 
 	/**
-	 * Sets the d d m structure key of this journal article.
+	 * Sets the ddm structure key of this journal article.
 	 *
-	 * @param DDMStructureKey the d d m structure key of this journal article
+	 * @param DDMStructureKey the ddm structure key of this journal article
 	 */
 	public void setDDMStructureKey(String DDMStructureKey);
 
 	/**
-	 * Returns the d d m template key of this journal article.
+	 * Returns the ddm template key of this journal article.
 	 *
-	 * @return the d d m template key of this journal article
+	 * @return the ddm template key of this journal article
 	 */
 	@AutoEscape
 	public String getDDMTemplateKey();
 
 	/**
-	 * Sets the d d m template key of this journal article.
+	 * Sets the ddm template key of this journal article.
 	 *
-	 * @param DDMTemplateKey the d d m template key of this journal article
+	 * @param DDMTemplateKey the ddm template key of this journal article
 	 */
 	public void setDDMTemplateKey(String DDMTemplateKey);
 
@@ -526,17 +526,17 @@ public interface JournalArticleModel extends AttachedModel,
 	public void setSmallImageId(long smallImageId);
 
 	/**
-	 * Returns the small image u r l of this journal article.
+	 * Returns the small image url of this journal article.
 	 *
-	 * @return the small image u r l of this journal article
+	 * @return the small image url of this journal article
 	 */
 	@AutoEscape
 	public String getSmallImageURL();
 
 	/**
-	 * Sets the small image u r l of this journal article.
+	 * Sets the small image url of this journal article.
 	 *
-	 * @param smallImageURL the small image u r l of this journal article
+	 * @param smallImageURL the small image url of this journal article
 	 */
 	public void setSmallImageURL(String smallImageURL);
 

--- a/journal-api/src/main/java/com/liferay/journal/model/JournalArticleWrapper.java
+++ b/journal-api/src/main/java/com/liferay/journal/model/JournalArticleWrapper.java
@@ -661,9 +661,9 @@ public class JournalArticleWrapper implements JournalArticle,
 	}
 
 	/**
-	* Returns the d d m structure key of this journal article.
+	* Returns the ddm structure key of this journal article.
 	*
-	* @return the d d m structure key of this journal article
+	* @return the ddm structure key of this journal article
 	*/
 	@Override
 	public java.lang.String getDDMStructureKey() {
@@ -671,9 +671,9 @@ public class JournalArticleWrapper implements JournalArticle,
 	}
 
 	/**
-	* Returns the d d m template key of this journal article.
+	* Returns the ddm template key of this journal article.
 	*
-	* @return the d d m template key of this journal article
+	* @return the ddm template key of this journal article
 	*/
 	@Override
 	public java.lang.String getDDMTemplateKey() {
@@ -757,9 +757,9 @@ public class JournalArticleWrapper implements JournalArticle,
 	}
 
 	/**
-	* Returns the small image u r l of this journal article.
+	* Returns the small image url of this journal article.
 	*
-	* @return the small image u r l of this journal article
+	* @return the small image url of this journal article
 	*/
 	@Override
 	public java.lang.String getSmallImageURL() {
@@ -1016,9 +1016,9 @@ public class JournalArticleWrapper implements JournalArticle,
 	}
 
 	/**
-	* Returns the class p k of this journal article.
+	* Returns the class pk of this journal article.
 	*
-	* @return the class p k of this journal article
+	* @return the class pk of this journal article
 	*/
 	@Override
 	public long getClassPK() {
@@ -1166,9 +1166,9 @@ public class JournalArticleWrapper implements JournalArticle,
 	}
 
 	/**
-	* Sets the class p k of this journal article.
+	* Sets the class pk of this journal article.
 	*
-	* @param classPK the class p k of this journal article
+	* @param classPK the class pk of this journal article
 	*/
 	@Override
 	public void setClassPK(long classPK) {
@@ -1206,9 +1206,9 @@ public class JournalArticleWrapper implements JournalArticle,
 	}
 
 	/**
-	* Sets the d d m structure key of this journal article.
+	* Sets the ddm structure key of this journal article.
 	*
-	* @param DDMStructureKey the d d m structure key of this journal article
+	* @param DDMStructureKey the ddm structure key of this journal article
 	*/
 	@Override
 	public void setDDMStructureKey(java.lang.String DDMStructureKey) {
@@ -1216,9 +1216,9 @@ public class JournalArticleWrapper implements JournalArticle,
 	}
 
 	/**
-	* Sets the d d m template key of this journal article.
+	* Sets the ddm template key of this journal article.
 	*
-	* @param DDMTemplateKey the d d m template key of this journal article
+	* @param DDMTemplateKey the ddm template key of this journal article
 	*/
 	@Override
 	public void setDDMTemplateKey(java.lang.String DDMTemplateKey) {
@@ -1432,9 +1432,9 @@ public class JournalArticleWrapper implements JournalArticle,
 	}
 
 	/**
-	* Sets the small image u r l of this journal article.
+	* Sets the small image url of this journal article.
 	*
-	* @param smallImageURL the small image u r l of this journal article
+	* @param smallImageURL the small image url of this journal article
 	*/
 	@Override
 	public void setSmallImageURL(java.lang.String smallImageURL) {

--- a/journal-api/src/main/java/com/liferay/journal/model/JournalFeedModel.java
+++ b/journal-api/src/main/java/com/liferay/journal/model/JournalFeedModel.java
@@ -254,47 +254,47 @@ public interface JournalFeedModel extends BaseModel<JournalFeed>, ShardedModel,
 	public void setDescription(String description);
 
 	/**
-	 * Returns the d d m structure key of this journal feed.
+	 * Returns the ddm structure key of this journal feed.
 	 *
-	 * @return the d d m structure key of this journal feed
+	 * @return the ddm structure key of this journal feed
 	 */
 	@AutoEscape
 	public String getDDMStructureKey();
 
 	/**
-	 * Sets the d d m structure key of this journal feed.
+	 * Sets the ddm structure key of this journal feed.
 	 *
-	 * @param DDMStructureKey the d d m structure key of this journal feed
+	 * @param DDMStructureKey the ddm structure key of this journal feed
 	 */
 	public void setDDMStructureKey(String DDMStructureKey);
 
 	/**
-	 * Returns the d d m template key of this journal feed.
+	 * Returns the ddm template key of this journal feed.
 	 *
-	 * @return the d d m template key of this journal feed
+	 * @return the ddm template key of this journal feed
 	 */
 	@AutoEscape
 	public String getDDMTemplateKey();
 
 	/**
-	 * Sets the d d m template key of this journal feed.
+	 * Sets the ddm template key of this journal feed.
 	 *
-	 * @param DDMTemplateKey the d d m template key of this journal feed
+	 * @param DDMTemplateKey the ddm template key of this journal feed
 	 */
 	public void setDDMTemplateKey(String DDMTemplateKey);
 
 	/**
-	 * Returns the d d m renderer template key of this journal feed.
+	 * Returns the ddm renderer template key of this journal feed.
 	 *
-	 * @return the d d m renderer template key of this journal feed
+	 * @return the ddm renderer template key of this journal feed
 	 */
 	@AutoEscape
 	public String getDDMRendererTemplateKey();
 
 	/**
-	 * Sets the d d m renderer template key of this journal feed.
+	 * Sets the ddm renderer template key of this journal feed.
 	 *
-	 * @param DDMRendererTemplateKey the d d m renderer template key of this journal feed
+	 * @param DDMRendererTemplateKey the ddm renderer template key of this journal feed
 	 */
 	public void setDDMRendererTemplateKey(String DDMRendererTemplateKey);
 

--- a/journal-api/src/main/java/com/liferay/journal/model/JournalFeedWrapper.java
+++ b/journal-api/src/main/java/com/liferay/journal/model/JournalFeedWrapper.java
@@ -316,9 +316,9 @@ public class JournalFeedWrapper implements JournalFeed,
 	}
 
 	/**
-	* Returns the d d m renderer template key of this journal feed.
+	* Returns the ddm renderer template key of this journal feed.
 	*
-	* @return the d d m renderer template key of this journal feed
+	* @return the ddm renderer template key of this journal feed
 	*/
 	@Override
 	public java.lang.String getDDMRendererTemplateKey() {
@@ -326,9 +326,9 @@ public class JournalFeedWrapper implements JournalFeed,
 	}
 
 	/**
-	* Returns the d d m structure key of this journal feed.
+	* Returns the ddm structure key of this journal feed.
 	*
-	* @return the d d m structure key of this journal feed
+	* @return the ddm structure key of this journal feed
 	*/
 	@Override
 	public java.lang.String getDDMStructureKey() {
@@ -336,9 +336,9 @@ public class JournalFeedWrapper implements JournalFeed,
 	}
 
 	/**
-	* Returns the d d m template key of this journal feed.
+	* Returns the ddm template key of this journal feed.
 	*
-	* @return the d d m template key of this journal feed
+	* @return the ddm template key of this journal feed
 	*/
 	@Override
 	public java.lang.String getDDMTemplateKey() {
@@ -613,9 +613,9 @@ public class JournalFeedWrapper implements JournalFeed,
 	}
 
 	/**
-	* Sets the d d m renderer template key of this journal feed.
+	* Sets the ddm renderer template key of this journal feed.
 	*
-	* @param DDMRendererTemplateKey the d d m renderer template key of this journal feed
+	* @param DDMRendererTemplateKey the ddm renderer template key of this journal feed
 	*/
 	@Override
 	public void setDDMRendererTemplateKey(
@@ -624,9 +624,9 @@ public class JournalFeedWrapper implements JournalFeed,
 	}
 
 	/**
-	* Sets the d d m structure key of this journal feed.
+	* Sets the ddm structure key of this journal feed.
 	*
-	* @param DDMStructureKey the d d m structure key of this journal feed
+	* @param DDMStructureKey the ddm structure key of this journal feed
 	*/
 	@Override
 	public void setDDMStructureKey(java.lang.String DDMStructureKey) {
@@ -634,9 +634,9 @@ public class JournalFeedWrapper implements JournalFeed,
 	}
 
 	/**
-	* Sets the d d m template key of this journal feed.
+	* Sets the ddm template key of this journal feed.
 	*
-	* @param DDMTemplateKey the d d m template key of this journal feed
+	* @param DDMTemplateKey the ddm template key of this journal feed
 	*/
 	@Override
 	public void setDDMTemplateKey(java.lang.String DDMTemplateKey) {

--- a/journal-api/src/main/java/com/liferay/journal/service/JournalFolderLocalService.java
+++ b/journal-api/src/main/java/com/liferay/journal/service/JournalFolderLocalService.java
@@ -398,6 +398,12 @@ public interface JournalFolderLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<JournalFolder> getNoAssetFolders();
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<DDMStructure> searchDDMStructures(long companyId,
+		long[] groupIds, long folderId, int restrictionType,
+		java.lang.String keywords, int start, int end,
+		OrderByComparator<DDMStructure> obc) throws PortalException;
+
 	/**
 	* Returns the number of rows matching the dynamic query.
 	*

--- a/journal-api/src/main/java/com/liferay/journal/service/JournalFolderLocalServiceUtil.java
+++ b/journal-api/src/main/java/com/liferay/journal/service/JournalFolderLocalServiceUtil.java
@@ -490,6 +490,16 @@ public class JournalFolderLocalServiceUtil {
 		return getService().getNoAssetFolders();
 	}
 
+	public static java.util.List<com.liferay.dynamic.data.mapping.model.DDMStructure> searchDDMStructures(
+		long companyId, long[] groupIds, long folderId, int restrictionType,
+		java.lang.String keywords, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.dynamic.data.mapping.model.DDMStructure> obc)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService()
+				   .searchDDMStructures(companyId, groupIds, folderId,
+			restrictionType, keywords, start, end, obc);
+	}
+
 	/**
 	* Returns the number of rows matching the dynamic query.
 	*

--- a/journal-api/src/main/java/com/liferay/journal/service/JournalFolderLocalServiceWrapper.java
+++ b/journal-api/src/main/java/com/liferay/journal/service/JournalFolderLocalServiceWrapper.java
@@ -547,6 +547,16 @@ public class JournalFolderLocalServiceWrapper
 		return _journalFolderLocalService.getNoAssetFolders();
 	}
 
+	@Override
+	public java.util.List<com.liferay.dynamic.data.mapping.model.DDMStructure> searchDDMStructures(
+		long companyId, long[] groupIds, long folderId, int restrictionType,
+		java.lang.String keywords, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.dynamic.data.mapping.model.DDMStructure> obc)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _journalFolderLocalService.searchDDMStructures(companyId,
+			groupIds, folderId, restrictionType, keywords, start, end, obc);
+	}
+
 	/**
 	* Returns the number of rows matching the dynamic query.
 	*

--- a/journal-api/src/main/java/com/liferay/journal/service/JournalFolderService.java
+++ b/journal-api/src/main/java/com/liferay/journal/service/JournalFolderService.java
@@ -166,6 +166,12 @@ public interface JournalFolderService extends BaseService {
 	public List<java.lang.Long> getSubfolderIds(long groupId, long folderId,
 		boolean recurse);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<DDMStructure> searchDDMStructures(long companyId,
+		long[] groupIds, long folderId, int restrictionType,
+		java.lang.String keywords, int start, int end,
+		OrderByComparator<DDMStructure> obc) throws PortalException;
+
 	public void deleteFolder(long folderId) throws PortalException;
 
 	public void deleteFolder(long folderId, boolean includeTrashedEntries)

--- a/journal-api/src/main/java/com/liferay/journal/service/JournalFolderServiceUtil.java
+++ b/journal-api/src/main/java/com/liferay/journal/service/JournalFolderServiceUtil.java
@@ -222,6 +222,16 @@ public class JournalFolderServiceUtil {
 		return getService().getSubfolderIds(groupId, folderId, recurse);
 	}
 
+	public static java.util.List<com.liferay.dynamic.data.mapping.model.DDMStructure> searchDDMStructures(
+		long companyId, long[] groupIds, long folderId, int restrictionType,
+		java.lang.String keywords, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.dynamic.data.mapping.model.DDMStructure> obc)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService()
+				   .searchDDMStructures(companyId, groupIds, folderId,
+			restrictionType, keywords, start, end, obc);
+	}
+
 	public static void deleteFolder(long folderId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		getService().deleteFolder(folderId);

--- a/journal-api/src/main/java/com/liferay/journal/service/JournalFolderServiceWrapper.java
+++ b/journal-api/src/main/java/com/liferay/journal/service/JournalFolderServiceWrapper.java
@@ -238,6 +238,16 @@ public class JournalFolderServiceWrapper implements JournalFolderService,
 	}
 
 	@Override
+	public java.util.List<com.liferay.dynamic.data.mapping.model.DDMStructure> searchDDMStructures(
+		long companyId, long[] groupIds, long folderId, int restrictionType,
+		java.lang.String keywords, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.dynamic.data.mapping.model.DDMStructure> obc)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _journalFolderService.searchDDMStructures(companyId, groupIds,
+			folderId, restrictionType, keywords, start, end, obc);
+	}
+
+	@Override
 	public void deleteFolder(long folderId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		_journalFolderService.deleteFolder(folderId);

--- a/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalArticleLocalizationPersistence.java
+++ b/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalArticleLocalizationPersistence.java
@@ -44,7 +44,7 @@ public interface JournalArticleLocalizationPersistence extends BasePersistence<J
 	/**
 	* Returns all the journal article localizations where articlePK = &#63;.
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @return the matching journal article localizations
 	*/
 	public java.util.List<JournalArticleLocalization> findByArticlePK(
@@ -57,7 +57,7 @@ public interface JournalArticleLocalizationPersistence extends BasePersistence<J
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleLocalizationModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param start the lower bound of the range of journal article localizations
 	* @param end the upper bound of the range of journal article localizations (not inclusive)
 	* @return the range of matching journal article localizations
@@ -72,7 +72,7 @@ public interface JournalArticleLocalizationPersistence extends BasePersistence<J
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleLocalizationModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param start the lower bound of the range of journal article localizations
 	* @param end the upper bound of the range of journal article localizations (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -89,7 +89,7 @@ public interface JournalArticleLocalizationPersistence extends BasePersistence<J
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleLocalizationModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param start the lower bound of the range of journal article localizations
 	* @param end the upper bound of the range of journal article localizations (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -104,7 +104,7 @@ public interface JournalArticleLocalizationPersistence extends BasePersistence<J
 	/**
 	* Returns the first journal article localization in the ordered set where articlePK = &#63;.
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article localization
 	* @throws NoSuchArticleLocalizationException if a matching journal article localization could not be found
@@ -116,7 +116,7 @@ public interface JournalArticleLocalizationPersistence extends BasePersistence<J
 	/**
 	* Returns the first journal article localization in the ordered set where articlePK = &#63;.
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article localization, or <code>null</code> if a matching journal article localization could not be found
 	*/
@@ -126,7 +126,7 @@ public interface JournalArticleLocalizationPersistence extends BasePersistence<J
 	/**
 	* Returns the last journal article localization in the ordered set where articlePK = &#63;.
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article localization
 	* @throws NoSuchArticleLocalizationException if a matching journal article localization could not be found
@@ -138,7 +138,7 @@ public interface JournalArticleLocalizationPersistence extends BasePersistence<J
 	/**
 	* Returns the last journal article localization in the ordered set where articlePK = &#63;.
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article localization, or <code>null</code> if a matching journal article localization could not be found
 	*/
@@ -149,7 +149,7 @@ public interface JournalArticleLocalizationPersistence extends BasePersistence<J
 	* Returns the journal article localizations before and after the current journal article localization in the ordered set where articlePK = &#63;.
 	*
 	* @param articleLocalizationId the primary key of the current journal article localization
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the previous, current, and next journal article localization
 	* @throws NoSuchArticleLocalizationException if a journal article localization with the primary key could not be found
@@ -162,14 +162,14 @@ public interface JournalArticleLocalizationPersistence extends BasePersistence<J
 	/**
 	* Removes all the journal article localizations where articlePK = &#63; from the database.
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	*/
 	public void removeByArticlePK(long articlePK);
 
 	/**
 	* Returns the number of journal article localizations where articlePK = &#63;.
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @return the number of matching journal article localizations
 	*/
 	public int countByArticlePK(long articlePK);
@@ -177,7 +177,7 @@ public interface JournalArticleLocalizationPersistence extends BasePersistence<J
 	/**
 	* Returns the journal article localization where articlePK = &#63; and languageId = &#63; or throws a {@link NoSuchArticleLocalizationException} if it could not be found.
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param languageId the language ID
 	* @return the matching journal article localization
 	* @throws NoSuchArticleLocalizationException if a matching journal article localization could not be found
@@ -188,7 +188,7 @@ public interface JournalArticleLocalizationPersistence extends BasePersistence<J
 	/**
 	* Returns the journal article localization where articlePK = &#63; and languageId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param languageId the language ID
 	* @return the matching journal article localization, or <code>null</code> if a matching journal article localization could not be found
 	*/
@@ -198,7 +198,7 @@ public interface JournalArticleLocalizationPersistence extends BasePersistence<J
 	/**
 	* Returns the journal article localization where articlePK = &#63; and languageId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param languageId the language ID
 	* @param retrieveFromCache whether to retrieve from the finder cache
 	* @return the matching journal article localization, or <code>null</code> if a matching journal article localization could not be found
@@ -209,7 +209,7 @@ public interface JournalArticleLocalizationPersistence extends BasePersistence<J
 	/**
 	* Removes the journal article localization where articlePK = &#63; and languageId = &#63; from the database.
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param languageId the language ID
 	* @return the journal article localization that was removed
 	*/
@@ -219,7 +219,7 @@ public interface JournalArticleLocalizationPersistence extends BasePersistence<J
 	/**
 	* Returns the number of journal article localizations where articlePK = &#63; and languageId = &#63;.
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param languageId the language ID
 	* @return the number of matching journal article localizations
 	*/

--- a/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalArticleLocalizationUtil.java
+++ b/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalArticleLocalizationUtil.java
@@ -118,7 +118,7 @@ public class JournalArticleLocalizationUtil {
 	/**
 	* Returns all the journal article localizations where articlePK = &#63;.
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @return the matching journal article localizations
 	*/
 	public static List<JournalArticleLocalization> findByArticlePK(
@@ -133,7 +133,7 @@ public class JournalArticleLocalizationUtil {
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleLocalizationModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param start the lower bound of the range of journal article localizations
 	* @param end the upper bound of the range of journal article localizations (not inclusive)
 	* @return the range of matching journal article localizations
@@ -150,7 +150,7 @@ public class JournalArticleLocalizationUtil {
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleLocalizationModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param start the lower bound of the range of journal article localizations
 	* @param end the upper bound of the range of journal article localizations (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -170,7 +170,7 @@ public class JournalArticleLocalizationUtil {
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleLocalizationModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param start the lower bound of the range of journal article localizations
 	* @param end the upper bound of the range of journal article localizations (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -189,7 +189,7 @@ public class JournalArticleLocalizationUtil {
 	/**
 	* Returns the first journal article localization in the ordered set where articlePK = &#63;.
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article localization
 	* @throws NoSuchArticleLocalizationException if a matching journal article localization could not be found
@@ -205,7 +205,7 @@ public class JournalArticleLocalizationUtil {
 	/**
 	* Returns the first journal article localization in the ordered set where articlePK = &#63;.
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article localization, or <code>null</code> if a matching journal article localization could not be found
 	*/
@@ -219,7 +219,7 @@ public class JournalArticleLocalizationUtil {
 	/**
 	* Returns the last journal article localization in the ordered set where articlePK = &#63;.
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article localization
 	* @throws NoSuchArticleLocalizationException if a matching journal article localization could not be found
@@ -235,7 +235,7 @@ public class JournalArticleLocalizationUtil {
 	/**
 	* Returns the last journal article localization in the ordered set where articlePK = &#63;.
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article localization, or <code>null</code> if a matching journal article localization could not be found
 	*/
@@ -250,7 +250,7 @@ public class JournalArticleLocalizationUtil {
 	* Returns the journal article localizations before and after the current journal article localization in the ordered set where articlePK = &#63;.
 	*
 	* @param articleLocalizationId the primary key of the current journal article localization
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the previous, current, and next journal article localization
 	* @throws NoSuchArticleLocalizationException if a journal article localization with the primary key could not be found
@@ -267,7 +267,7 @@ public class JournalArticleLocalizationUtil {
 	/**
 	* Removes all the journal article localizations where articlePK = &#63; from the database.
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	*/
 	public static void removeByArticlePK(long articlePK) {
 		getPersistence().removeByArticlePK(articlePK);
@@ -276,7 +276,7 @@ public class JournalArticleLocalizationUtil {
 	/**
 	* Returns the number of journal article localizations where articlePK = &#63;.
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @return the number of matching journal article localizations
 	*/
 	public static int countByArticlePK(long articlePK) {
@@ -286,7 +286,7 @@ public class JournalArticleLocalizationUtil {
 	/**
 	* Returns the journal article localization where articlePK = &#63; and languageId = &#63; or throws a {@link NoSuchArticleLocalizationException} if it could not be found.
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param languageId the language ID
 	* @return the matching journal article localization
 	* @throws NoSuchArticleLocalizationException if a matching journal article localization could not be found
@@ -300,7 +300,7 @@ public class JournalArticleLocalizationUtil {
 	/**
 	* Returns the journal article localization where articlePK = &#63; and languageId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param languageId the language ID
 	* @return the matching journal article localization, or <code>null</code> if a matching journal article localization could not be found
 	*/
@@ -312,7 +312,7 @@ public class JournalArticleLocalizationUtil {
 	/**
 	* Returns the journal article localization where articlePK = &#63; and languageId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param languageId the language ID
 	* @param retrieveFromCache whether to retrieve from the finder cache
 	* @return the matching journal article localization, or <code>null</code> if a matching journal article localization could not be found
@@ -326,7 +326,7 @@ public class JournalArticleLocalizationUtil {
 	/**
 	* Removes the journal article localization where articlePK = &#63; and languageId = &#63; from the database.
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param languageId the language ID
 	* @return the journal article localization that was removed
 	*/
@@ -339,7 +339,7 @@ public class JournalArticleLocalizationUtil {
 	/**
 	* Returns the number of journal article localizations where articlePK = &#63; and languageId = &#63;.
 	*
-	* @param articlePK the article p k
+	* @param articlePK the article pk
 	* @param languageId the language ID
 	* @return the number of matching journal article localizations
 	*/

--- a/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalArticlePersistence.java
+++ b/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalArticlePersistence.java
@@ -834,7 +834,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	/**
 	* Returns all the journal articles where DDMStructureKey = &#63;.
 	*
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @return the matching journal articles
 	*/
 	public java.util.List<JournalArticle> findByDDMStructureKey(
@@ -847,7 +847,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @return the range of matching journal articles
@@ -862,7 +862,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -879,7 +879,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -894,7 +894,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	/**
 	* Returns the first journal article in the ordered set where DDMStructureKey = &#63;.
 	*
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -907,7 +907,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	/**
 	* Returns the first journal article in the ordered set where DDMStructureKey = &#63;.
 	*
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -918,7 +918,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	/**
 	* Returns the last journal article in the ordered set where DDMStructureKey = &#63;.
 	*
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -931,7 +931,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	/**
 	* Returns the last journal article in the ordered set where DDMStructureKey = &#63;.
 	*
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -943,7 +943,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Returns the journal articles before and after the current journal article in the ordered set where DDMStructureKey = &#63;.
 	*
 	* @param id the primary key of the current journal article
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the previous, current, and next journal article
 	* @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -960,7 +960,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param DDMStructureKeies the d d m structure keies
+	* @param DDMStructureKeies the ddm structure keies
 	* @return the matching journal articles
 	*/
 	public java.util.List<JournalArticle> findByDDMStructureKey(
@@ -973,7 +973,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param DDMStructureKeies the d d m structure keies
+	* @param DDMStructureKeies the ddm structure keies
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @return the range of matching journal articles
@@ -988,7 +988,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param DDMStructureKeies the d d m structure keies
+	* @param DDMStructureKeies the ddm structure keies
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -1005,7 +1005,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -1020,14 +1020,14 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	/**
 	* Removes all the journal articles where DDMStructureKey = &#63; from the database.
 	*
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	*/
 	public void removeByDDMStructureKey(java.lang.String DDMStructureKey);
 
 	/**
 	* Returns the number of journal articles where DDMStructureKey = &#63;.
 	*
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @return the number of matching journal articles
 	*/
 	public int countByDDMStructureKey(java.lang.String DDMStructureKey);
@@ -1035,7 +1035,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	/**
 	* Returns the number of journal articles where DDMStructureKey = any &#63;.
 	*
-	* @param DDMStructureKeies the d d m structure keies
+	* @param DDMStructureKeies the ddm structure keies
 	* @return the number of matching journal articles
 	*/
 	public int countByDDMStructureKey(java.lang.String[] DDMStructureKeies);
@@ -1043,7 +1043,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	/**
 	* Returns all the journal articles where DDMTemplateKey = &#63;.
 	*
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @return the matching journal articles
 	*/
 	public java.util.List<JournalArticle> findByDDMTemplateKey(
@@ -1056,7 +1056,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @return the range of matching journal articles
@@ -1071,7 +1071,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -1088,7 +1088,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -1103,7 +1103,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	/**
 	* Returns the first journal article in the ordered set where DDMTemplateKey = &#63;.
 	*
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -1116,7 +1116,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	/**
 	* Returns the first journal article in the ordered set where DDMTemplateKey = &#63;.
 	*
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -1127,7 +1127,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	/**
 	* Returns the last journal article in the ordered set where DDMTemplateKey = &#63;.
 	*
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -1140,7 +1140,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	/**
 	* Returns the last journal article in the ordered set where DDMTemplateKey = &#63;.
 	*
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -1152,7 +1152,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Returns the journal articles before and after the current journal article in the ordered set where DDMTemplateKey = &#63;.
 	*
 	* @param id the primary key of the current journal article
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the previous, current, and next journal article
 	* @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -1165,14 +1165,14 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	/**
 	* Removes all the journal articles where DDMTemplateKey = &#63; from the database.
 	*
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	*/
 	public void removeByDDMTemplateKey(java.lang.String DDMTemplateKey);
 
 	/**
 	* Returns the number of journal articles where DDMTemplateKey = &#63;.
 	*
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @return the number of matching journal articles
 	*/
 	public int countByDDMTemplateKey(java.lang.String DDMTemplateKey);
@@ -2799,7 +2799,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Returns all the journal articles where groupId = &#63; and DDMStructureKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @return the matching journal articles
 	*/
 	public java.util.List<JournalArticle> findByG_DDMSK(long groupId,
@@ -2813,7 +2813,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* </p>
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @return the range of matching journal articles
@@ -2829,7 +2829,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* </p>
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -2847,7 +2847,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* </p>
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -2863,7 +2863,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Returns the first journal article in the ordered set where groupId = &#63; and DDMStructureKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -2877,7 +2877,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Returns the first journal article in the ordered set where groupId = &#63; and DDMStructureKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -2889,7 +2889,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Returns the last journal article in the ordered set where groupId = &#63; and DDMStructureKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -2903,7 +2903,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Returns the last journal article in the ordered set where groupId = &#63; and DDMStructureKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -2916,7 +2916,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param id the primary key of the current journal article
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the previous, current, and next journal article
 	* @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -2930,7 +2930,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Returns all the journal articles that the user has permission to view where groupId = &#63; and DDMStructureKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @return the matching journal articles that the user has permission to view
 	*/
 	public java.util.List<JournalArticle> filterFindByG_DDMSK(long groupId,
@@ -2944,7 +2944,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* </p>
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @return the range of matching journal articles that the user has permission to view
@@ -2960,7 +2960,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* </p>
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -2975,7 +2975,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param id the primary key of the current journal article
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the previous, current, and next journal article
 	* @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -2989,7 +2989,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Removes all the journal articles where groupId = &#63; and DDMStructureKey = &#63; from the database.
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	*/
 	public void removeByG_DDMSK(long groupId, java.lang.String DDMStructureKey);
 
@@ -2997,7 +2997,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Returns the number of journal articles where groupId = &#63; and DDMStructureKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @return the number of matching journal articles
 	*/
 	public int countByG_DDMSK(long groupId, java.lang.String DDMStructureKey);
@@ -3006,7 +3006,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Returns the number of journal articles that the user has permission to view where groupId = &#63; and DDMStructureKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @return the number of matching journal articles that the user has permission to view
 	*/
 	public int filterCountByG_DDMSK(long groupId,
@@ -3016,7 +3016,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Returns all the journal articles where groupId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @return the matching journal articles
 	*/
 	public java.util.List<JournalArticle> findByG_DDMTK(long groupId,
@@ -3030,7 +3030,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* </p>
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @return the range of matching journal articles
@@ -3046,7 +3046,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* </p>
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -3064,7 +3064,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* </p>
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -3080,7 +3080,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Returns the first journal article in the ordered set where groupId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -3094,7 +3094,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Returns the first journal article in the ordered set where groupId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -3106,7 +3106,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Returns the last journal article in the ordered set where groupId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -3120,7 +3120,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Returns the last journal article in the ordered set where groupId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -3133,7 +3133,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param id the primary key of the current journal article
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the previous, current, and next journal article
 	* @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -3147,7 +3147,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Returns all the journal articles that the user has permission to view where groupId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @return the matching journal articles that the user has permission to view
 	*/
 	public java.util.List<JournalArticle> filterFindByG_DDMTK(long groupId,
@@ -3161,7 +3161,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* </p>
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @return the range of matching journal articles that the user has permission to view
@@ -3177,7 +3177,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* </p>
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -3192,7 +3192,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param id the primary key of the current journal article
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the previous, current, and next journal article
 	* @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -3206,7 +3206,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Removes all the journal articles where groupId = &#63; and DDMTemplateKey = &#63; from the database.
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	*/
 	public void removeByG_DDMTK(long groupId, java.lang.String DDMTemplateKey);
 
@@ -3214,7 +3214,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Returns the number of journal articles where groupId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @return the number of matching journal articles
 	*/
 	public int countByG_DDMTK(long groupId, java.lang.String DDMTemplateKey);
@@ -3223,7 +3223,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Returns the number of journal articles that the user has permission to view where groupId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @return the number of matching journal articles that the user has permission to view
 	*/
 	public int filterCountByG_DDMTK(long groupId,
@@ -4437,7 +4437,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Returns all the journal articles where classNameId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @return the matching journal articles
 	*/
 	public java.util.List<JournalArticle> findByC_DDMTK(long classNameId,
@@ -4451,7 +4451,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* </p>
 	*
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @return the range of matching journal articles
@@ -4467,7 +4467,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* </p>
 	*
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -4485,7 +4485,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* </p>
 	*
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -4501,7 +4501,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Returns the first journal article in the ordered set where classNameId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -4515,7 +4515,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Returns the first journal article in the ordered set where classNameId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -4527,7 +4527,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Returns the last journal article in the ordered set where classNameId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -4541,7 +4541,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Returns the last journal article in the ordered set where classNameId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -4554,7 +4554,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param id the primary key of the current journal article
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the previous, current, and next journal article
 	* @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -4568,7 +4568,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Removes all the journal articles where classNameId = &#63; and DDMTemplateKey = &#63; from the database.
 	*
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	*/
 	public void removeByC_DDMTK(long classNameId,
 		java.lang.String DDMTemplateKey);
@@ -4577,7 +4577,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* Returns the number of journal articles where classNameId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @return the number of matching journal articles
 	*/
 	public int countByC_DDMTK(long classNameId, java.lang.String DDMTemplateKey);
@@ -5577,7 +5577,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @return the matching journal articles
 	*/
 	public java.util.List<JournalArticle> findByG_C_C(long groupId,
@@ -5592,7 +5592,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @return the range of matching journal articles
@@ -5609,7 +5609,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -5628,7 +5628,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -5645,7 +5645,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -5660,7 +5660,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -5673,7 +5673,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -5688,7 +5688,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -5702,7 +5702,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* @param id the primary key of the current journal article
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the previous, current, and next journal article
 	* @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -5717,7 +5717,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @return the matching journal articles that the user has permission to view
 	*/
 	public java.util.List<JournalArticle> filterFindByG_C_C(long groupId,
@@ -5732,7 +5732,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @return the range of matching journal articles that the user has permission to view
@@ -5749,7 +5749,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -5765,7 +5765,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* @param id the primary key of the current journal article
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the previous, current, and next journal article
 	* @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -5780,7 +5780,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	*/
 	public void removeByG_C_C(long groupId, long classNameId, long classPK);
 
@@ -5789,7 +5789,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @return the number of matching journal articles
 	*/
 	public int countByG_C_C(long groupId, long classNameId, long classPK);
@@ -5799,7 +5799,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @return the number of matching journal articles that the user has permission to view
 	*/
 	public int filterCountByG_C_C(long groupId, long classNameId, long classPK);
@@ -5809,7 +5809,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @return the matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
 	*/
@@ -5821,7 +5821,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @return the matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
 	public JournalArticle fetchByG_C_DDMSK(long groupId, long classNameId,
@@ -5832,7 +5832,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param retrieveFromCache whether to retrieve from the finder cache
 	* @return the matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -5844,7 +5844,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @return the journal article that was removed
 	*/
 	public JournalArticle removeByG_C_DDMSK(long groupId, long classNameId,
@@ -5855,7 +5855,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @return the number of matching journal articles
 	*/
 	public int countByG_C_DDMSK(long groupId, long classNameId,
@@ -5866,7 +5866,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @return the matching journal articles
 	*/
 	public java.util.List<JournalArticle> findByG_C_DDMTK(long groupId,
@@ -5881,7 +5881,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @return the range of matching journal articles
@@ -5898,7 +5898,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -5917,7 +5917,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -5934,7 +5934,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -5949,7 +5949,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -5962,7 +5962,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -5977,7 +5977,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -5991,7 +5991,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* @param id the primary key of the current journal article
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the previous, current, and next journal article
 	* @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -6006,7 +6006,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @return the matching journal articles that the user has permission to view
 	*/
 	public java.util.List<JournalArticle> filterFindByG_C_DDMTK(long groupId,
@@ -6021,7 +6021,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @return the range of matching journal articles that the user has permission to view
@@ -6038,7 +6038,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -6054,7 +6054,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	* @param id the primary key of the current journal article
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the previous, current, and next journal article
 	* @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -6069,7 +6069,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	*/
 	public void removeByG_C_DDMTK(long groupId, long classNameId,
 		java.lang.String DDMTemplateKey);
@@ -6079,7 +6079,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @return the number of matching journal articles
 	*/
 	public int countByG_C_DDMTK(long groupId, long classNameId,
@@ -6090,7 +6090,7 @@ public interface JournalArticlePersistence extends BasePersistence<JournalArticl
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @return the number of matching journal articles that the user has permission to view
 	*/
 	public int filterCountByG_C_DDMTK(long groupId, long classNameId,

--- a/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalArticleUtil.java
+++ b/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalArticleUtil.java
@@ -1071,7 +1071,7 @@ public class JournalArticleUtil {
 	/**
 	* Returns all the journal articles where DDMStructureKey = &#63;.
 	*
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @return the matching journal articles
 	*/
 	public static List<JournalArticle> findByDDMStructureKey(
@@ -1086,7 +1086,7 @@ public class JournalArticleUtil {
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @return the range of matching journal articles
@@ -1104,7 +1104,7 @@ public class JournalArticleUtil {
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -1125,7 +1125,7 @@ public class JournalArticleUtil {
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -1144,7 +1144,7 @@ public class JournalArticleUtil {
 	/**
 	* Returns the first journal article in the ordered set where DDMStructureKey = &#63;.
 	*
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -1161,7 +1161,7 @@ public class JournalArticleUtil {
 	/**
 	* Returns the first journal article in the ordered set where DDMStructureKey = &#63;.
 	*
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -1176,7 +1176,7 @@ public class JournalArticleUtil {
 	/**
 	* Returns the last journal article in the ordered set where DDMStructureKey = &#63;.
 	*
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -1193,7 +1193,7 @@ public class JournalArticleUtil {
 	/**
 	* Returns the last journal article in the ordered set where DDMStructureKey = &#63;.
 	*
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -1209,7 +1209,7 @@ public class JournalArticleUtil {
 	* Returns the journal articles before and after the current journal article in the ordered set where DDMStructureKey = &#63;.
 	*
 	* @param id the primary key of the current journal article
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the previous, current, and next journal article
 	* @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -1230,7 +1230,7 @@ public class JournalArticleUtil {
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param DDMStructureKeies the d d m structure keies
+	* @param DDMStructureKeies the ddm structure keies
 	* @return the matching journal articles
 	*/
 	public static List<JournalArticle> findByDDMStructureKey(
@@ -1245,7 +1245,7 @@ public class JournalArticleUtil {
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param DDMStructureKeies the d d m structure keies
+	* @param DDMStructureKeies the ddm structure keies
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @return the range of matching journal articles
@@ -1263,7 +1263,7 @@ public class JournalArticleUtil {
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param DDMStructureKeies the d d m structure keies
+	* @param DDMStructureKeies the ddm structure keies
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -1284,7 +1284,7 @@ public class JournalArticleUtil {
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -1303,7 +1303,7 @@ public class JournalArticleUtil {
 	/**
 	* Removes all the journal articles where DDMStructureKey = &#63; from the database.
 	*
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	*/
 	public static void removeByDDMStructureKey(java.lang.String DDMStructureKey) {
 		getPersistence().removeByDDMStructureKey(DDMStructureKey);
@@ -1312,7 +1312,7 @@ public class JournalArticleUtil {
 	/**
 	* Returns the number of journal articles where DDMStructureKey = &#63;.
 	*
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @return the number of matching journal articles
 	*/
 	public static int countByDDMStructureKey(java.lang.String DDMStructureKey) {
@@ -1322,7 +1322,7 @@ public class JournalArticleUtil {
 	/**
 	* Returns the number of journal articles where DDMStructureKey = any &#63;.
 	*
-	* @param DDMStructureKeies the d d m structure keies
+	* @param DDMStructureKeies the ddm structure keies
 	* @return the number of matching journal articles
 	*/
 	public static int countByDDMStructureKey(
@@ -1333,7 +1333,7 @@ public class JournalArticleUtil {
 	/**
 	* Returns all the journal articles where DDMTemplateKey = &#63;.
 	*
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @return the matching journal articles
 	*/
 	public static List<JournalArticle> findByDDMTemplateKey(
@@ -1348,7 +1348,7 @@ public class JournalArticleUtil {
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @return the range of matching journal articles
@@ -1365,7 +1365,7 @@ public class JournalArticleUtil {
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -1386,7 +1386,7 @@ public class JournalArticleUtil {
 	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	* </p>
 	*
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -1405,7 +1405,7 @@ public class JournalArticleUtil {
 	/**
 	* Returns the first journal article in the ordered set where DDMTemplateKey = &#63;.
 	*
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -1421,7 +1421,7 @@ public class JournalArticleUtil {
 	/**
 	* Returns the first journal article in the ordered set where DDMTemplateKey = &#63;.
 	*
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -1436,7 +1436,7 @@ public class JournalArticleUtil {
 	/**
 	* Returns the last journal article in the ordered set where DDMTemplateKey = &#63;.
 	*
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -1452,7 +1452,7 @@ public class JournalArticleUtil {
 	/**
 	* Returns the last journal article in the ordered set where DDMTemplateKey = &#63;.
 	*
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -1467,7 +1467,7 @@ public class JournalArticleUtil {
 	* Returns the journal articles before and after the current journal article in the ordered set where DDMTemplateKey = &#63;.
 	*
 	* @param id the primary key of the current journal article
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the previous, current, and next journal article
 	* @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -1484,7 +1484,7 @@ public class JournalArticleUtil {
 	/**
 	* Removes all the journal articles where DDMTemplateKey = &#63; from the database.
 	*
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	*/
 	public static void removeByDDMTemplateKey(java.lang.String DDMTemplateKey) {
 		getPersistence().removeByDDMTemplateKey(DDMTemplateKey);
@@ -1493,7 +1493,7 @@ public class JournalArticleUtil {
 	/**
 	* Returns the number of journal articles where DDMTemplateKey = &#63;.
 	*
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @return the number of matching journal articles
 	*/
 	public static int countByDDMTemplateKey(java.lang.String DDMTemplateKey) {
@@ -3460,7 +3460,7 @@ public class JournalArticleUtil {
 	* Returns all the journal articles where groupId = &#63; and DDMStructureKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @return the matching journal articles
 	*/
 	public static List<JournalArticle> findByG_DDMSK(long groupId,
@@ -3476,7 +3476,7 @@ public class JournalArticleUtil {
 	* </p>
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @return the range of matching journal articles
@@ -3495,7 +3495,7 @@ public class JournalArticleUtil {
 	* </p>
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -3517,7 +3517,7 @@ public class JournalArticleUtil {
 	* </p>
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -3537,7 +3537,7 @@ public class JournalArticleUtil {
 	* Returns the first journal article in the ordered set where groupId = &#63; and DDMStructureKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -3555,7 +3555,7 @@ public class JournalArticleUtil {
 	* Returns the first journal article in the ordered set where groupId = &#63; and DDMStructureKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -3571,7 +3571,7 @@ public class JournalArticleUtil {
 	* Returns the last journal article in the ordered set where groupId = &#63; and DDMStructureKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -3589,7 +3589,7 @@ public class JournalArticleUtil {
 	* Returns the last journal article in the ordered set where groupId = &#63; and DDMStructureKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -3606,7 +3606,7 @@ public class JournalArticleUtil {
 	*
 	* @param id the primary key of the current journal article
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the previous, current, and next journal article
 	* @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -3624,7 +3624,7 @@ public class JournalArticleUtil {
 	* Returns all the journal articles that the user has permission to view where groupId = &#63; and DDMStructureKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @return the matching journal articles that the user has permission to view
 	*/
 	public static List<JournalArticle> filterFindByG_DDMSK(long groupId,
@@ -3640,7 +3640,7 @@ public class JournalArticleUtil {
 	* </p>
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @return the range of matching journal articles that the user has permission to view
@@ -3659,7 +3659,7 @@ public class JournalArticleUtil {
 	* </p>
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -3678,7 +3678,7 @@ public class JournalArticleUtil {
 	*
 	* @param id the primary key of the current journal article
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the previous, current, and next journal article
 	* @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -3696,7 +3696,7 @@ public class JournalArticleUtil {
 	* Removes all the journal articles where groupId = &#63; and DDMStructureKey = &#63; from the database.
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	*/
 	public static void removeByG_DDMSK(long groupId,
 		java.lang.String DDMStructureKey) {
@@ -3707,7 +3707,7 @@ public class JournalArticleUtil {
 	* Returns the number of journal articles where groupId = &#63; and DDMStructureKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @return the number of matching journal articles
 	*/
 	public static int countByG_DDMSK(long groupId,
@@ -3719,7 +3719,7 @@ public class JournalArticleUtil {
 	* Returns the number of journal articles that the user has permission to view where groupId = &#63; and DDMStructureKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @return the number of matching journal articles that the user has permission to view
 	*/
 	public static int filterCountByG_DDMSK(long groupId,
@@ -3731,7 +3731,7 @@ public class JournalArticleUtil {
 	* Returns all the journal articles where groupId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @return the matching journal articles
 	*/
 	public static List<JournalArticle> findByG_DDMTK(long groupId,
@@ -3747,7 +3747,7 @@ public class JournalArticleUtil {
 	* </p>
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @return the range of matching journal articles
@@ -3766,7 +3766,7 @@ public class JournalArticleUtil {
 	* </p>
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -3788,7 +3788,7 @@ public class JournalArticleUtil {
 	* </p>
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -3808,7 +3808,7 @@ public class JournalArticleUtil {
 	* Returns the first journal article in the ordered set where groupId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -3826,7 +3826,7 @@ public class JournalArticleUtil {
 	* Returns the first journal article in the ordered set where groupId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -3842,7 +3842,7 @@ public class JournalArticleUtil {
 	* Returns the last journal article in the ordered set where groupId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -3860,7 +3860,7 @@ public class JournalArticleUtil {
 	* Returns the last journal article in the ordered set where groupId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -3877,7 +3877,7 @@ public class JournalArticleUtil {
 	*
 	* @param id the primary key of the current journal article
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the previous, current, and next journal article
 	* @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -3895,7 +3895,7 @@ public class JournalArticleUtil {
 	* Returns all the journal articles that the user has permission to view where groupId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @return the matching journal articles that the user has permission to view
 	*/
 	public static List<JournalArticle> filterFindByG_DDMTK(long groupId,
@@ -3911,7 +3911,7 @@ public class JournalArticleUtil {
 	* </p>
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @return the range of matching journal articles that the user has permission to view
@@ -3930,7 +3930,7 @@ public class JournalArticleUtil {
 	* </p>
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -3949,7 +3949,7 @@ public class JournalArticleUtil {
 	*
 	* @param id the primary key of the current journal article
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the previous, current, and next journal article
 	* @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -3967,7 +3967,7 @@ public class JournalArticleUtil {
 	* Removes all the journal articles where groupId = &#63; and DDMTemplateKey = &#63; from the database.
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	*/
 	public static void removeByG_DDMTK(long groupId,
 		java.lang.String DDMTemplateKey) {
@@ -3978,7 +3978,7 @@ public class JournalArticleUtil {
 	* Returns the number of journal articles where groupId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @return the number of matching journal articles
 	*/
 	public static int countByG_DDMTK(long groupId,
@@ -3990,7 +3990,7 @@ public class JournalArticleUtil {
 	* Returns the number of journal articles that the user has permission to view where groupId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param groupId the group ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @return the number of matching journal articles that the user has permission to view
 	*/
 	public static int filterCountByG_DDMTK(long groupId,
@@ -5459,7 +5459,7 @@ public class JournalArticleUtil {
 	* Returns all the journal articles where classNameId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @return the matching journal articles
 	*/
 	public static List<JournalArticle> findByC_DDMTK(long classNameId,
@@ -5475,7 +5475,7 @@ public class JournalArticleUtil {
 	* </p>
 	*
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @return the range of matching journal articles
@@ -5494,7 +5494,7 @@ public class JournalArticleUtil {
 	* </p>
 	*
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -5516,7 +5516,7 @@ public class JournalArticleUtil {
 	* </p>
 	*
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -5536,7 +5536,7 @@ public class JournalArticleUtil {
 	* Returns the first journal article in the ordered set where classNameId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -5554,7 +5554,7 @@ public class JournalArticleUtil {
 	* Returns the first journal article in the ordered set where classNameId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -5570,7 +5570,7 @@ public class JournalArticleUtil {
 	* Returns the last journal article in the ordered set where classNameId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -5588,7 +5588,7 @@ public class JournalArticleUtil {
 	* Returns the last journal article in the ordered set where classNameId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -5605,7 +5605,7 @@ public class JournalArticleUtil {
 	*
 	* @param id the primary key of the current journal article
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the previous, current, and next journal article
 	* @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -5623,7 +5623,7 @@ public class JournalArticleUtil {
 	* Removes all the journal articles where classNameId = &#63; and DDMTemplateKey = &#63; from the database.
 	*
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	*/
 	public static void removeByC_DDMTK(long classNameId,
 		java.lang.String DDMTemplateKey) {
@@ -5634,7 +5634,7 @@ public class JournalArticleUtil {
 	* Returns the number of journal articles where classNameId = &#63; and DDMTemplateKey = &#63;.
 	*
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @return the number of matching journal articles
 	*/
 	public static int countByC_DDMTK(long classNameId,
@@ -6850,7 +6850,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @return the matching journal articles
 	*/
 	public static List<JournalArticle> findByG_C_C(long groupId,
@@ -6867,7 +6867,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @return the range of matching journal articles
@@ -6887,7 +6887,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -6910,7 +6910,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -6931,7 +6931,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -6950,7 +6950,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -6967,7 +6967,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -6986,7 +6986,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -7004,7 +7004,7 @@ public class JournalArticleUtil {
 	* @param id the primary key of the current journal article
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the previous, current, and next journal article
 	* @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -7023,7 +7023,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @return the matching journal articles that the user has permission to view
 	*/
 	public static List<JournalArticle> filterFindByG_C_C(long groupId,
@@ -7040,7 +7040,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @return the range of matching journal articles that the user has permission to view
@@ -7060,7 +7060,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -7080,7 +7080,7 @@ public class JournalArticleUtil {
 	* @param id the primary key of the current journal article
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the previous, current, and next journal article
 	* @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -7099,7 +7099,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	*/
 	public static void removeByG_C_C(long groupId, long classNameId,
 		long classPK) {
@@ -7111,7 +7111,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @return the number of matching journal articles
 	*/
 	public static int countByG_C_C(long groupId, long classNameId, long classPK) {
@@ -7123,7 +7123,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param classPK the class p k
+	* @param classPK the class pk
 	* @return the number of matching journal articles that the user has permission to view
 	*/
 	public static int filterCountByG_C_C(long groupId, long classNameId,
@@ -7136,7 +7136,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @return the matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
 	*/
@@ -7152,7 +7152,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @return the matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
 	public static JournalArticle fetchByG_C_DDMSK(long groupId,
@@ -7166,7 +7166,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @param retrieveFromCache whether to retrieve from the finder cache
 	* @return the matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -7183,7 +7183,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @return the journal article that was removed
 	*/
 	public static JournalArticle removeByG_C_DDMSK(long groupId,
@@ -7198,7 +7198,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMStructureKey the d d m structure key
+	* @param DDMStructureKey the ddm structure key
 	* @return the number of matching journal articles
 	*/
 	public static int countByG_C_DDMSK(long groupId, long classNameId,
@@ -7212,7 +7212,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @return the matching journal articles
 	*/
 	public static List<JournalArticle> findByG_C_DDMTK(long groupId,
@@ -7230,7 +7230,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @return the range of matching journal articles
@@ -7251,7 +7251,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -7274,7 +7274,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -7295,7 +7295,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -7314,7 +7314,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the first matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -7331,7 +7331,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article
 	* @throws NoSuchArticleException if a matching journal article could not be found
@@ -7350,7 +7350,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the last matching journal article, or <code>null</code> if a matching journal article could not be found
 	*/
@@ -7368,7 +7368,7 @@ public class JournalArticleUtil {
 	* @param id the primary key of the current journal article
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the previous, current, and next journal article
 	* @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -7387,7 +7387,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @return the matching journal articles that the user has permission to view
 	*/
 	public static List<JournalArticle> filterFindByG_C_DDMTK(long groupId,
@@ -7405,7 +7405,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @return the range of matching journal articles that the user has permission to view
@@ -7426,7 +7426,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param start the lower bound of the range of journal articles
 	* @param end the upper bound of the range of journal articles (not inclusive)
 	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -7446,7 +7446,7 @@ public class JournalArticleUtil {
 	* @param id the primary key of the current journal article
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	* @return the previous, current, and next journal article
 	* @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -7465,7 +7465,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	*/
 	public static void removeByG_C_DDMTK(long groupId, long classNameId,
 		java.lang.String DDMTemplateKey) {
@@ -7477,7 +7477,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @return the number of matching journal articles
 	*/
 	public static int countByG_C_DDMTK(long groupId, long classNameId,
@@ -7491,7 +7491,7 @@ public class JournalArticleUtil {
 	*
 	* @param groupId the group ID
 	* @param classNameId the class name ID
-	* @param DDMTemplateKey the d d m template key
+	* @param DDMTemplateKey the ddm template key
 	* @return the number of matching journal articles that the user has permission to view
 	*/
 	public static int filterCountByG_C_DDMTK(long groupId, long classNameId,

--- a/journal-content-web/bnd.bnd
+++ b/journal-content-web/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Journal Content Web
 Bundle-SymbolicName: com.liferay.journal.content.web
-Bundle-Version: 1.1.8
+Bundle-Version: 1.1.9
 Export-Package: com.liferay.journal.content.web.constants
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title: Web Content

--- a/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
+++ b/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
@@ -254,33 +254,34 @@ public class JournalContentExportImportPortletPreferencesProcessor
 
 		try {
 			if (Validator.isNotNull(articleId)) {
-				Map<String, String> articleIds =
-					(Map<String, String>)
-						portletDataContext.getNewPrimaryKeysMap(
-							JournalArticle.class + ".articleId");
-
-				articleId = MapUtil.getString(articleIds, articleId, articleId);
-
-				portletPreferences.setValue("articleId", articleId);
-
 				Group importedArticleGroup = _groupLocalService.getGroup(
 					groupId);
 
 				if (importedArticleGroup.isStagedPortlet(
 						JournalPortletKeys.JOURNAL)) {
 
+					Map<String, String> articleIds =
+						(Map<String, String>)
+							portletDataContext.getNewPrimaryKeysMap(
+								JournalArticle.class + ".articleId");
+
+					articleId = MapUtil.getString(
+						articleIds, articleId, articleId);
+
+					portletPreferences.setValue("articleId", articleId);
+
 					portletPreferences.setValue(
 						"groupId", String.valueOf(groupId));
-				}
 
-				if (portletDataContext.getPlid() > 0) {
-					Layout layout = _layoutLocalService.fetchLayout(
-						portletDataContext.getPlid());
+					if (portletDataContext.getPlid() > 0) {
+						Layout layout = _layoutLocalService.fetchLayout(
+							portletDataContext.getPlid());
 
-					_journalContentSearchLocalService.updateContentSearch(
-						layout.getGroupId(), layout.isPrivateLayout(),
-						layout.getLayoutId(), portletDataContext.getPortletId(),
-						articleId, true);
+						_journalContentSearchLocalService.updateContentSearch(
+							layout.getGroupId(), layout.isPrivateLayout(),
+							layout.getLayoutId(),
+							portletDataContext.getPortletId(), articleId, true);
+					}
 				}
 			}
 

--- a/journal-lang/bnd.bnd
+++ b/journal-lang/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-Name: Liferay Journal Lang
 Bundle-SymbolicName: com.liferay.journal.lang
-Bundle-Version: 2.0.4
+Bundle-Version: 2.0.5
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title: Data Management

--- a/journal-service/build.gradle
+++ b/journal-service/build.gradle
@@ -10,7 +10,7 @@ buildService {
 
 dependencies {
 	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
-	provided group: "com.liferay", name: "com.liferay.dynamic.data.mapping.api", version: "3.6.0-20170105.185234-4"
+	provided group: "com.liferay", name: "com.liferay.dynamic.data.mapping.api", version: "3.6.0-20170303.140213-11"
 	provided group: "com.liferay", name: "com.liferay.dynamic.data.mapping.service", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.exportimport.api", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.exportimport.service", version: "3.3.0"

--- a/journal-service/build.gradle
+++ b/journal-service/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.xstream.configurator.api", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.10.0-20160915.164248-1"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.23.0-20170223.232845-1"
 	provided group: "com.liferay.portal", name: "com.liferay.util.java", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "2.0.0"
 	provided group: "commons-lang", name: "commons-lang", version: "2.1"

--- a/journal-service/build.gradle
+++ b/journal-service/build.gradle
@@ -1,3 +1,6 @@
+sourceCompatibility = "1.8"
+targetCompatibility = "1.8"
+
 apply plugin: "com.liferay.lang.merger"
 
 buildService {

--- a/journal-service/build.gradle
+++ b/journal-service/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.xstream.configurator.api", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.23.0-20170223.232845-1"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.util.java", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "2.0.0"
 	provided group: "commons-lang", name: "commons-lang", version: "2.1"

--- a/journal-service/src/main/java/com/liferay/journal/exportimport/data/handler/JournalPortletDataHandler.java
+++ b/journal-service/src/main/java/com/liferay/journal/exportimport/data/handler/JournalPortletDataHandler.java
@@ -162,6 +162,7 @@ public class JournalPortletDataHandler extends BasePortletDataHandler {
 			new PortletDataHandlerBoolean(
 				NAMESPACE, "folders", true, false, null,
 				JournalFolder.class.getName()));
+		setSupportsDataStrategyMirrorWithOverwriting(false);
 	}
 
 	@Override

--- a/journal-service/src/main/java/com/liferay/journal/internal/exportimport/lifecycle/JournalCacheExportImportLifecycleListener.java
+++ b/journal-service/src/main/java/com/liferay/journal/internal/exportimport/lifecycle/JournalCacheExportImportLifecycleListener.java
@@ -15,10 +15,12 @@
 package com.liferay.journal.internal.exportimport.lifecycle;
 
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
-import com.liferay.exportimport.kernel.lifecycle.BaseExportImportLifecycleListener;
+import com.liferay.exportimport.kernel.lifecycle.EventAwareExportImportLifecycleListener;
 import com.liferay.exportimport.kernel.lifecycle.ExportImportLifecycleListener;
+import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
 import com.liferay.journal.constants.JournalPortletKeys;
 import com.liferay.journal.util.JournalContent;
+import com.liferay.portal.kernel.model.StagedModel;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -28,19 +30,37 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(service = ExportImportLifecycleListener.class)
 public class JournalCacheExportImportLifecycleListener
-	extends BaseExportImportLifecycleListener {
+	implements EventAwareExportImportLifecycleListener {
 
 	@Override
 	public boolean isParallel() {
 		return false;
 	}
 
-	protected void clearCache() {
-		_journalContent.clearCache();
+	@Override
+	public void onLayoutExportFailed(
+			PortletDataContext portletDataContext, Throwable throwable)
+		throws Exception {
 	}
 
 	@Override
-	protected void onLayoutImportProcessFinished(
+	public void onLayoutExportStarted(PortletDataContext portletDataContext)
+		throws Exception {
+	}
+
+	@Override
+	public void onLayoutExportSucceeded(PortletDataContext portletDataContext)
+		throws Exception {
+	}
+
+	@Override
+	public void onLayoutImportFailed(
+			PortletDataContext portletDataContext, Throwable throwable)
+		throws Exception {
+	}
+
+	@Override
+	public void onLayoutImportProcessFinished(
 			PortletDataContext portletDataContext)
 		throws Exception {
 
@@ -48,7 +68,77 @@ public class JournalCacheExportImportLifecycleListener
 	}
 
 	@Override
-	protected void onPortletImportProcessFinished(
+	public void onLayoutImportStarted(PortletDataContext portletDataContext)
+		throws Exception {
+	}
+
+	@Override
+	public void onLayoutImportSucceeded(PortletDataContext portletDataContext)
+		throws Exception {
+	}
+
+	@Override
+	public void onLayoutLocalPublicationFailed(
+			ExportImportConfiguration exportImportConfiguration,
+			Throwable throwable)
+		throws Exception {
+	}
+
+	@Override
+	public void onLayoutLocalPublicationStarted(
+			ExportImportConfiguration exportImportConfiguration)
+		throws Exception {
+	}
+
+	@Override
+	public void onLayoutLocalPublicationSucceeded(
+			ExportImportConfiguration exportImportConfiguration)
+		throws Exception {
+	}
+
+	@Override
+	public void onLayoutRemotePublicationFailed(
+			ExportImportConfiguration exportImportConfiguration,
+			Throwable throwable)
+		throws Exception {
+	}
+
+	@Override
+	public void onLayoutRemotePublicationStarted(
+			ExportImportConfiguration exportImportConfiguration)
+		throws Exception {
+	}
+
+	@Override
+	public void onLayoutRemotePublicationSucceeded(
+			ExportImportConfiguration exportImportConfiguration)
+		throws Exception {
+	}
+
+	@Override
+	public void onPortletExportFailed(
+			PortletDataContext portletDataContext, Throwable throwable)
+		throws Exception {
+	}
+
+	@Override
+	public void onPortletExportStarted(PortletDataContext portletDataContext)
+		throws Exception {
+	}
+
+	@Override
+	public void onPortletExportSucceeded(PortletDataContext portletDataContext)
+		throws Exception {
+	}
+
+	@Override
+	public void onPortletImportFailed(
+			PortletDataContext portletDataContext, Throwable throwable)
+		throws Exception {
+	}
+
+	@Override
+	public void onPortletImportProcessFinished(
 			PortletDataContext portletDataContext)
 		throws Exception {
 
@@ -59,6 +149,77 @@ public class JournalCacheExportImportLifecycleListener
 		}
 
 		clearCache();
+	}
+
+	@Override
+	public void onPortletImportStarted(PortletDataContext portletDataContext)
+		throws Exception {
+	}
+
+	@Override
+	public void onPortletImportSucceeded(PortletDataContext portletDataContext)
+		throws Exception {
+	}
+
+	@Override
+	public void onPortletPublicationFailed(
+			ExportImportConfiguration exportImportConfiguration,
+			Throwable throwable)
+		throws Exception {
+	}
+
+	@Override
+	public void onPortletPublicationStarted(
+			ExportImportConfiguration exportImportConfiguration)
+		throws Exception {
+	}
+
+	@Override
+	public void onPortletPublicationSucceeded(
+			ExportImportConfiguration exportImportConfiguration)
+		throws Exception {
+	}
+
+	@Override
+	public void onStagedModelExportFailed(
+			PortletDataContext portletDataContext, StagedModel stagedModel,
+			Throwable throwable)
+		throws Exception {
+	}
+
+	@Override
+	public void onStagedModelExportStarted(
+			PortletDataContext portletDataContext, StagedModel stagedModel)
+		throws Exception {
+	}
+
+	@Override
+	public void onStagedModelExportSucceeded(
+			PortletDataContext portletDataContext, StagedModel stagedModel)
+		throws Exception {
+	}
+
+	@Override
+	public void onStagedModelImportFailed(
+			PortletDataContext portletDataContext, StagedModel stagedModel,
+			Throwable throwable)
+		throws Exception {
+	}
+
+	@Override
+	public void onStagedModelImportStarted(
+			PortletDataContext portletDataContext, StagedModel stagedModel)
+		throws Exception {
+	}
+
+	@Override
+	public void onStagedModelImportSucceeded(
+			PortletDataContext portletDataContext, StagedModel stagedModel)
+		throws Exception {
+	}
+
+	protected void clearCache() {
+		_journalContent.clearCache();
 	}
 
 	@Reference(unbind = "-")

--- a/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v0_0_5/UpgradeCompanyId.java
+++ b/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v0_0_5/UpgradeCompanyId.java
@@ -22,6 +22,15 @@ import com.liferay.portal.kernel.upgrade.BaseUpgradeCompanyId;
 public class UpgradeCompanyId extends BaseUpgradeCompanyId {
 
 	@Override
+	protected void doUpgrade() throws Exception {
+		super.doUpgrade();
+
+		runSQL(
+			"create index IX_CC7576C7 on JournalArticleResource " +
+				"(uuid_[$COLUMN_LENGTH:75$], companyId)");
+	}
+
+	@Override
 	protected TableUpdater[] getTableUpdaters() {
 		return new TableUpdater[] {
 			new TableUpdater("JournalArticleImage", "Group_", "groupId"),

--- a/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/UpgradeDocumentLibraryTypeContent.java
+++ b/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/UpgradeDocumentLibraryTypeContent.java
@@ -137,10 +137,13 @@ public class UpgradeDocumentLibraryTypeContent extends UpgradeProcess {
 
 		long groupId = GetterUtil.getLong(parts[2]);
 
-		String uuid = parts[5];
+		String uuid = null;
 
 		if (parts.length == 5) {
 			uuid = getUuidByDocumentLibraryURLWithoutUuid(parts);
+		}
+		else {
+			uuid = parts[5];
 		}
 
 		return _dlAppLocalService.getFileEntryByUuidAndGroupId(uuid, groupId);

--- a/journal-service/src/main/java/com/liferay/journal/service/base/JournalArticleLocalServiceBaseImpl.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/base/JournalArticleLocalServiceBaseImpl.java
@@ -1171,18 +1171,18 @@ public abstract class JournalArticleLocalServiceBaseImpl
 	}
 
 	/**
-	 * Returns the d l app local service.
+	 * Returns the dl app local service.
 	 *
-	 * @return the d l app local service
+	 * @return the dl app local service
 	 */
 	public com.liferay.document.library.kernel.service.DLAppLocalService getDLAppLocalService() {
 		return dlAppLocalService;
 	}
 
 	/**
-	 * Sets the d l app local service.
+	 * Sets the dl app local service.
 	 *
-	 * @param dlAppLocalService the d l app local service
+	 * @param dlAppLocalService the dl app local service
 	 */
 	public void setDLAppLocalService(
 		com.liferay.document.library.kernel.service.DLAppLocalService dlAppLocalService) {

--- a/journal-service/src/main/java/com/liferay/journal/service/base/JournalArticleLocalServiceBaseImpl.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/base/JournalArticleLocalServiceBaseImpl.java
@@ -80,6 +80,7 @@ import com.liferay.portal.kernel.service.persistence.WorkflowDefinitionLinkPersi
 import com.liferay.portal.kernel.service.persistence.WorkflowInstanceLinkPersistence;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.spring.extender.service.ServiceReference;
 
@@ -91,6 +92,7 @@ import com.liferay.trash.kernel.service.persistence.TrashVersionPersistence;
 import java.io.Serializable;
 
 import java.util.List;
+import java.util.Set;
 
 import javax.sql.DataSource;
 
@@ -351,6 +353,16 @@ public abstract class JournalArticleLocalServiceBaseImpl
 		exportActionableDynamicQuery.setAddCriteriaMethod(new ActionableDynamicQuery.AddCriteriaMethod() {
 				@Override
 				public void addCriteria(DynamicQuery dynamicQuery) {
+					Set<Serializable> primaryKeys = portletDataContext.getRegisteredExportingClassedModelPrimaryKeys(
+							"JournalArticle");
+
+					if (SetUtil.isNotEmpty(primaryKeys)) {
+						Property primaryKeyProperty = PropertyFactoryUtil.forName(
+								"id");
+
+						dynamicQuery.add(primaryKeyProperty.in(primaryKeys));
+					}
+
 					Criterion modifiedDateCriterion = portletDataContext.getDateRangeCriteria(
 							"modifiedDate");
 

--- a/journal-service/src/main/java/com/liferay/journal/service/base/JournalArticleServiceBaseImpl.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/base/JournalArticleServiceBaseImpl.java
@@ -911,18 +911,18 @@ public abstract class JournalArticleServiceBaseImpl extends BaseServiceImpl
 	}
 
 	/**
-	 * Returns the d l app local service.
+	 * Returns the dl app local service.
 	 *
-	 * @return the d l app local service
+	 * @return the dl app local service
 	 */
 	public com.liferay.document.library.kernel.service.DLAppLocalService getDLAppLocalService() {
 		return dlAppLocalService;
 	}
 
 	/**
-	 * Sets the d l app local service.
+	 * Sets the dl app local service.
 	 *
-	 * @param dlAppLocalService the d l app local service
+	 * @param dlAppLocalService the dl app local service
 	 */
 	public void setDLAppLocalService(
 		com.liferay.document.library.kernel.service.DLAppLocalService dlAppLocalService) {
@@ -930,18 +930,18 @@ public abstract class JournalArticleServiceBaseImpl extends BaseServiceImpl
 	}
 
 	/**
-	 * Returns the d l app remote service.
+	 * Returns the dl app remote service.
 	 *
-	 * @return the d l app remote service
+	 * @return the dl app remote service
 	 */
 	public com.liferay.document.library.kernel.service.DLAppService getDLAppService() {
 		return dlAppService;
 	}
 
 	/**
-	 * Sets the d l app remote service.
+	 * Sets the dl app remote service.
 	 *
-	 * @param dlAppService the d l app remote service
+	 * @param dlAppService the dl app remote service
 	 */
 	public void setDLAppService(
 		com.liferay.document.library.kernel.service.DLAppService dlAppService) {

--- a/journal-service/src/main/java/com/liferay/journal/service/base/JournalFeedLocalServiceBaseImpl.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/base/JournalFeedLocalServiceBaseImpl.java
@@ -41,6 +41,8 @@ import com.liferay.portal.kernel.dao.orm.DynamicQueryFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.ExportActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Projection;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.model.PersistedModel;
@@ -54,11 +56,13 @@ import com.liferay.portal.kernel.service.persistence.SystemEventPersistence;
 import com.liferay.portal.kernel.service.persistence.UserPersistence;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.spring.extender.service.ServiceReference;
 
 import java.io.Serializable;
 
 import java.util.List;
+import java.util.Set;
 
 import javax.sql.DataSource;
 
@@ -312,6 +316,16 @@ public abstract class JournalFeedLocalServiceBaseImpl
 		exportActionableDynamicQuery.setAddCriteriaMethod(new ActionableDynamicQuery.AddCriteriaMethod() {
 				@Override
 				public void addCriteria(DynamicQuery dynamicQuery) {
+					Set<Serializable> primaryKeys = portletDataContext.getRegisteredExportingClassedModelPrimaryKeys(
+							"JournalFeed");
+
+					if (SetUtil.isNotEmpty(primaryKeys)) {
+						Property primaryKeyProperty = PropertyFactoryUtil.forName(
+								"id");
+
+						dynamicQuery.add(primaryKeyProperty.in(primaryKeys));
+					}
+
 					portletDataContext.addDateRangeCriteria(dynamicQuery,
 						"modifiedDate");
 				}

--- a/journal-service/src/main/java/com/liferay/journal/service/base/JournalFolderLocalServiceBaseImpl.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/base/JournalFolderLocalServiceBaseImpl.java
@@ -70,6 +70,7 @@ import com.liferay.portal.kernel.service.persistence.WorkflowDefinitionLinkPersi
 import com.liferay.portal.kernel.service.persistence.WorkflowInstanceLinkPersistence;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.spring.extender.service.ServiceReference;
 
@@ -81,6 +82,7 @@ import com.liferay.trash.kernel.service.persistence.TrashVersionPersistence;
 import java.io.Serializable;
 
 import java.util.List;
+import java.util.Set;
 
 import javax.sql.DataSource;
 
@@ -336,6 +338,16 @@ public abstract class JournalFolderLocalServiceBaseImpl
 		exportActionableDynamicQuery.setAddCriteriaMethod(new ActionableDynamicQuery.AddCriteriaMethod() {
 				@Override
 				public void addCriteria(DynamicQuery dynamicQuery) {
+					Set<Serializable> primaryKeys = portletDataContext.getRegisteredExportingClassedModelPrimaryKeys(
+							"JournalFolder");
+
+					if (SetUtil.isNotEmpty(primaryKeys)) {
+						Property primaryKeyProperty = PropertyFactoryUtil.forName(
+								"folderId");
+
+						dynamicQuery.add(primaryKeyProperty.in(primaryKeys));
+					}
+
 					Criterion modifiedDateCriterion = portletDataContext.getDateRangeCriteria(
 							"modifiedDate");
 

--- a/journal-service/src/main/java/com/liferay/journal/service/http/JournalFolderServiceHttp.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/http/JournalFolderServiceHttp.java
@@ -892,12 +892,48 @@ public class JournalFolderServiceHttp {
 		}
 	}
 
+	public static java.util.List<com.liferay.dynamic.data.mapping.model.DDMStructure> searchDDMStructures(
+		HttpPrincipal httpPrincipal, long companyId, long[] groupIds,
+		long folderId, int restrictionType, java.lang.String keywords,
+		int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.dynamic.data.mapping.model.DDMStructure> obc)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		try {
+			MethodKey methodKey = new MethodKey(JournalFolderServiceUtil.class,
+					"searchDDMStructures", _searchDDMStructuresParameterTypes29);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey,
+					companyId, groupIds, folderId, restrictionType, keywords,
+					start, end, obc);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (java.util.List<com.liferay.dynamic.data.mapping.model.DDMStructure>)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
 	public static void subscribe(HttpPrincipal httpPrincipal, long groupId,
 		long folderId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(JournalFolderServiceUtil.class,
-					"subscribe", _subscribeParameterTypes29);
+					"subscribe", _subscribeParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					folderId);
@@ -925,7 +961,7 @@ public class JournalFolderServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(JournalFolderServiceUtil.class,
-					"unsubscribe", _unsubscribeParameterTypes30);
+					"unsubscribe", _unsubscribeParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					folderId);
@@ -956,7 +992,7 @@ public class JournalFolderServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(JournalFolderServiceUtil.class,
-					"updateFolder", _updateFolderParameterTypes31);
+					"updateFolder", _updateFolderParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					folderId, parentFolderId, name, description,
@@ -993,7 +1029,7 @@ public class JournalFolderServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(JournalFolderServiceUtil.class,
-					"updateFolder", _updateFolderParameterTypes32);
+					"updateFolder", _updateFolderParameterTypes33);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					folderId, parentFolderId, name, description,
@@ -1119,18 +1155,23 @@ public class JournalFolderServiceHttp {
 	private static final Class<?>[] _restoreFolderFromTrashParameterTypes28 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _subscribeParameterTypes29 = new Class[] {
+	private static final Class<?>[] _searchDDMStructuresParameterTypes29 = new Class[] {
+			long.class, long[].class, long.class, int.class,
+			java.lang.String.class, int.class, int.class,
+			com.liferay.portal.kernel.util.OrderByComparator.class
+		};
+	private static final Class<?>[] _subscribeParameterTypes30 = new Class[] {
 			long.class, long.class
 		};
-	private static final Class<?>[] _unsubscribeParameterTypes30 = new Class[] {
+	private static final Class<?>[] _unsubscribeParameterTypes31 = new Class[] {
 			long.class, long.class
 		};
-	private static final Class<?>[] _updateFolderParameterTypes31 = new Class[] {
+	private static final Class<?>[] _updateFolderParameterTypes32 = new Class[] {
 			long.class, long.class, long.class, java.lang.String.class,
 			java.lang.String.class, boolean.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateFolderParameterTypes32 = new Class[] {
+	private static final Class<?>[] _updateFolderParameterTypes33 = new Class[] {
 			long.class, long.class, long.class, java.lang.String.class,
 			java.lang.String.class, long[].class, int.class, boolean.class,
 			com.liferay.portal.kernel.service.ServiceContext.class

--- a/journal-service/src/main/java/com/liferay/journal/service/http/JournalFolderServiceSoap.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/http/JournalFolderServiceSoap.java
@@ -441,6 +441,26 @@ public class JournalFolderServiceSoap {
 		}
 	}
 
+	public static com.liferay.dynamic.data.mapping.model.DDMStructureSoap[] searchDDMStructures(
+		long companyId, long[] groupIds, long folderId, int restrictionType,
+		java.lang.String keywords, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.dynamic.data.mapping.model.DDMStructure> obc)
+		throws RemoteException {
+		try {
+			java.util.List<com.liferay.dynamic.data.mapping.model.DDMStructure> returnValue =
+				JournalFolderServiceUtil.searchDDMStructures(companyId,
+					groupIds, folderId, restrictionType, keywords, start, end,
+					obc);
+
+			return com.liferay.dynamic.data.mapping.model.DDMStructureSoap.toSoapModels(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
 	public static void subscribe(long groupId, long folderId)
 		throws RemoteException {
 		try {

--- a/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -97,6 +97,7 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.notifications.UserNotificationDefinition;
@@ -155,6 +156,7 @@ import com.liferay.portal.kernel.util.SubscriptionSender;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.workflow.WorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowHandlerRegistryUtil;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.DocumentException;
@@ -828,10 +830,16 @@ public class JournalArticleLocalServiceImpl
 		newArticle.setSmallImageId(counterLocalService.increment());
 		newArticle.setSmallImageURL(oldArticle.getSmallImageURL());
 
-		if (oldArticle.isPending() ||
-			workflowDefinitionLinkLocalService.hasWorkflowDefinitionLink(
-				user.getCompanyId(), groupId, JournalArticle.class.getName())) {
+		WorkflowHandler workflowHandler =
+			WorkflowHandlerRegistryUtil.getWorkflowHandler(
+				JournalArticle.class.getName());
 
+		WorkflowDefinitionLink workflowDefinitionLink =
+			workflowHandler.getWorkflowDefinitionLink(
+				oldArticle.getCompanyId(), oldArticle.getGroupId(),
+				oldArticle.getId());
+
+		if (oldArticle.isPending() || (workflowDefinitionLink != null)) {
 			newArticle.setStatus(WorkflowConstants.STATUS_DRAFT);
 		}
 		else {

--- a/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderLocalServiceImpl.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderLocalServiceImpl.java
@@ -758,6 +758,38 @@ public class JournalFolderLocalServiceImpl
 	}
 
 	@Override
+	public List<DDMStructure> searchDDMStructures(
+			long companyId, long[] groupIds, long folderId, int restrictionType,
+			String keywords, int start, int end,
+			OrderByComparator<DDMStructure> obc)
+		throws PortalException {
+
+		if (restrictionType ==
+				JournalFolderConstants.
+					RESTRICTION_TYPE_DDM_STRUCTURES_AND_WORKFLOW) {
+
+			return ddmStructureLocalService.search(
+				companyId, groupIds,
+				classNameLocalService.getClassNameId(JournalFolder.class),
+				folderId, keywords, start, end, obc);
+		}
+
+		folderId = getOverridedDDMStructuresFolderId(folderId);
+
+		if (folderId != JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+			return ddmStructureLocalService.search(
+				companyId, groupIds,
+				classNameLocalService.getClassNameId(JournalFolder.class),
+				folderId, keywords, start, end, obc);
+		}
+
+		return ddmStructureLocalService.search(
+			companyId, groupIds,
+			classNameLocalService.getClassNameId(JournalArticle.class),
+			keywords, WorkflowConstants.STATUS_ANY, start, end, obc);
+	}
+
+	@Override
 	public void subscribe(long userId, long groupId, long folderId)
 		throws PortalException {
 

--- a/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderServiceImpl.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderServiceImpl.java
@@ -364,6 +364,19 @@ public class JournalFolderServiceImpl extends JournalFolderServiceBaseImpl {
 	}
 
 	@Override
+	public List<DDMStructure> searchDDMStructures(
+			long companyId, long[] groupIds, long folderId, int restrictionType,
+			String keywords, int start, int end,
+			OrderByComparator<DDMStructure> obc)
+		throws PortalException {
+
+		return filterStructures(
+			journalFolderLocalService.searchDDMStructures(
+				companyId, groupIds, folderId, restrictionType, keywords, start,
+				end, obc));
+	}
+
+	@Override
 	public void subscribe(long groupId, long folderId) throws PortalException {
 		JournalFolderPermission.check(
 			getPermissionChecker(), groupId, folderId, ActionKeys.SUBSCRIBE);

--- a/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticleLocalizationPersistenceImpl.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticleLocalizationPersistenceImpl.java
@@ -114,7 +114,7 @@ public class JournalArticleLocalizationPersistenceImpl
 	/**
 	 * Returns all the journal article localizations where articlePK = &#63;.
 	 *
-	 * @param articlePK the article p k
+	 * @param articlePK the article pk
 	 * @return the matching journal article localizations
 	 */
 	@Override
@@ -130,7 +130,7 @@ public class JournalArticleLocalizationPersistenceImpl
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleLocalizationModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
-	 * @param articlePK the article p k
+	 * @param articlePK the article pk
 	 * @param start the lower bound of the range of journal article localizations
 	 * @param end the upper bound of the range of journal article localizations (not inclusive)
 	 * @return the range of matching journal article localizations
@@ -148,7 +148,7 @@ public class JournalArticleLocalizationPersistenceImpl
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleLocalizationModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
-	 * @param articlePK the article p k
+	 * @param articlePK the article pk
 	 * @param start the lower bound of the range of journal article localizations
 	 * @param end the upper bound of the range of journal article localizations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -168,7 +168,7 @@ public class JournalArticleLocalizationPersistenceImpl
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleLocalizationModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
-	 * @param articlePK the article p k
+	 * @param articlePK the article pk
 	 * @param start the lower bound of the range of journal article localizations
 	 * @param end the upper bound of the range of journal article localizations (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -282,7 +282,7 @@ public class JournalArticleLocalizationPersistenceImpl
 	/**
 	 * Returns the first journal article localization in the ordered set where articlePK = &#63;.
 	 *
-	 * @param articlePK the article p k
+	 * @param articlePK the article pk
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching journal article localization
 	 * @throws NoSuchArticleLocalizationException if a matching journal article localization could not be found
@@ -313,7 +313,7 @@ public class JournalArticleLocalizationPersistenceImpl
 	/**
 	 * Returns the first journal article localization in the ordered set where articlePK = &#63;.
 	 *
-	 * @param articlePK the article p k
+	 * @param articlePK the article pk
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching journal article localization, or <code>null</code> if a matching journal article localization could not be found
 	 */
@@ -333,7 +333,7 @@ public class JournalArticleLocalizationPersistenceImpl
 	/**
 	 * Returns the last journal article localization in the ordered set where articlePK = &#63;.
 	 *
-	 * @param articlePK the article p k
+	 * @param articlePK the article pk
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching journal article localization
 	 * @throws NoSuchArticleLocalizationException if a matching journal article localization could not be found
@@ -364,7 +364,7 @@ public class JournalArticleLocalizationPersistenceImpl
 	/**
 	 * Returns the last journal article localization in the ordered set where articlePK = &#63;.
 	 *
-	 * @param articlePK the article p k
+	 * @param articlePK the article pk
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching journal article localization, or <code>null</code> if a matching journal article localization could not be found
 	 */
@@ -391,7 +391,7 @@ public class JournalArticleLocalizationPersistenceImpl
 	 * Returns the journal article localizations before and after the current journal article localization in the ordered set where articlePK = &#63;.
 	 *
 	 * @param articleLocalizationId the primary key of the current journal article localization
-	 * @param articlePK the article p k
+	 * @param articlePK the article pk
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the previous, current, and next journal article localization
 	 * @throws NoSuchArticleLocalizationException if a journal article localization with the primary key could not be found
@@ -541,7 +541,7 @@ public class JournalArticleLocalizationPersistenceImpl
 	/**
 	 * Removes all the journal article localizations where articlePK = &#63; from the database.
 	 *
-	 * @param articlePK the article p k
+	 * @param articlePK the article pk
 	 */
 	@Override
 	public void removeByArticlePK(long articlePK) {
@@ -554,7 +554,7 @@ public class JournalArticleLocalizationPersistenceImpl
 	/**
 	 * Returns the number of journal article localizations where articlePK = &#63;.
 	 *
-	 * @param articlePK the article p k
+	 * @param articlePK the article pk
 	 * @return the number of matching journal article localizations
 	 */
 	@Override
@@ -619,7 +619,7 @@ public class JournalArticleLocalizationPersistenceImpl
 	/**
 	 * Returns the journal article localization where articlePK = &#63; and languageId = &#63; or throws a {@link NoSuchArticleLocalizationException} if it could not be found.
 	 *
-	 * @param articlePK the article p k
+	 * @param articlePK the article pk
 	 * @param languageId the language ID
 	 * @return the matching journal article localization
 	 * @throws NoSuchArticleLocalizationException if a matching journal article localization could not be found
@@ -656,7 +656,7 @@ public class JournalArticleLocalizationPersistenceImpl
 	/**
 	 * Returns the journal article localization where articlePK = &#63; and languageId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
-	 * @param articlePK the article p k
+	 * @param articlePK the article pk
 	 * @param languageId the language ID
 	 * @return the matching journal article localization, or <code>null</code> if a matching journal article localization could not be found
 	 */
@@ -669,7 +669,7 @@ public class JournalArticleLocalizationPersistenceImpl
 	/**
 	 * Returns the journal article localization where articlePK = &#63; and languageId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
-	 * @param articlePK the article p k
+	 * @param articlePK the article pk
 	 * @param languageId the language ID
 	 * @param retrieveFromCache whether to retrieve from the finder cache
 	 * @return the matching journal article localization, or <code>null</code> if a matching journal article localization could not be found
@@ -777,7 +777,7 @@ public class JournalArticleLocalizationPersistenceImpl
 	/**
 	 * Removes the journal article localization where articlePK = &#63; and languageId = &#63; from the database.
 	 *
-	 * @param articlePK the article p k
+	 * @param articlePK the article pk
 	 * @param languageId the language ID
 	 * @return the journal article localization that was removed
 	 */
@@ -793,7 +793,7 @@ public class JournalArticleLocalizationPersistenceImpl
 	/**
 	 * Returns the number of journal article localizations where articlePK = &#63; and languageId = &#63;.
 	 *
-	 * @param articlePK the article p k
+	 * @param articlePK the article pk
 	 * @param languageId the language ID
 	 * @return the number of matching journal article localizations
 	 */
@@ -1139,9 +1139,22 @@ public class JournalArticleLocalizationPersistenceImpl
 
 		finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITH_PAGINATION);
 
-		if (isNew ||
-				!JournalArticleLocalizationModelImpl.COLUMN_BITMASK_ENABLED) {
+		if (!JournalArticleLocalizationModelImpl.COLUMN_BITMASK_ENABLED) {
 			finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION);
+		}
+		else
+		 if (isNew) {
+			Object[] args = new Object[] {
+					journalArticleLocalizationModelImpl.getArticlePK()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_ARTICLEPK, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_ARTICLEPK,
+				args);
+
+			finderCache.removeResult(FINDER_PATH_COUNT_ALL, FINDER_ARGS_EMPTY);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_ALL,
+				FINDER_ARGS_EMPTY);
 		}
 
 		else {

--- a/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticlePersistenceImpl.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticlePersistenceImpl.java
@@ -3418,7 +3418,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	/**
 	 * Returns all the journal articles where DDMStructureKey = &#63;.
 	 *
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @return the matching journal articles
 	 */
 	@Override
@@ -3434,7 +3434,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @return the range of matching journal articles
@@ -3452,7 +3452,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -3472,7 +3472,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -3605,7 +3605,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	/**
 	 * Returns the first journal article in the ordered set where DDMStructureKey = &#63;.
 	 *
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching journal article
 	 * @throws NoSuchArticleException if a matching journal article could not be found
@@ -3636,7 +3636,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	/**
 	 * Returns the first journal article in the ordered set where DDMStructureKey = &#63;.
 	 *
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching journal article, or <code>null</code> if a matching journal article could not be found
 	 */
@@ -3656,7 +3656,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	/**
 	 * Returns the last journal article in the ordered set where DDMStructureKey = &#63;.
 	 *
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching journal article
 	 * @throws NoSuchArticleException if a matching journal article could not be found
@@ -3687,7 +3687,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	/**
 	 * Returns the last journal article in the ordered set where DDMStructureKey = &#63;.
 	 *
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching journal article, or <code>null</code> if a matching journal article could not be found
 	 */
@@ -3714,7 +3714,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Returns the journal articles before and after the current journal article in the ordered set where DDMStructureKey = &#63;.
 	 *
 	 * @param id the primary key of the current journal article
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the previous, current, and next journal article
 	 * @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -3878,7 +3878,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
-	 * @param DDMStructureKeies the d d m structure keies
+	 * @param DDMStructureKeies the ddm structure keies
 	 * @return the matching journal articles
 	 */
 	@Override
@@ -3895,7 +3895,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
-	 * @param DDMStructureKeies the d d m structure keies
+	 * @param DDMStructureKeies the ddm structure keies
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @return the range of matching journal articles
@@ -3913,7 +3913,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
-	 * @param DDMStructureKeies the d d m structure keies
+	 * @param DDMStructureKeies the ddm structure keies
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -3934,7 +3934,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -4089,7 +4089,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	/**
 	 * Removes all the journal articles where DDMStructureKey = &#63; from the database.
 	 *
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 */
 	@Override
 	public void removeByDDMStructureKey(String DDMStructureKey) {
@@ -4102,7 +4102,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	/**
 	 * Returns the number of journal articles where DDMStructureKey = &#63;.
 	 *
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @return the number of matching journal articles
 	 */
 	@Override
@@ -4167,7 +4167,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	/**
 	 * Returns the number of journal articles where DDMStructureKey = any &#63;.
 	 *
-	 * @param DDMStructureKeies the d d m structure keies
+	 * @param DDMStructureKeies the ddm structure keies
 	 * @return the number of matching journal articles
 	 */
 	@Override
@@ -4290,7 +4290,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	/**
 	 * Returns all the journal articles where DDMTemplateKey = &#63;.
 	 *
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @return the matching journal articles
 	 */
 	@Override
@@ -4306,7 +4306,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @return the range of matching journal articles
@@ -4324,7 +4324,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -4344,7 +4344,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link JournalArticleModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -4477,7 +4477,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	/**
 	 * Returns the first journal article in the ordered set where DDMTemplateKey = &#63;.
 	 *
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching journal article
 	 * @throws NoSuchArticleException if a matching journal article could not be found
@@ -4508,7 +4508,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	/**
 	 * Returns the first journal article in the ordered set where DDMTemplateKey = &#63;.
 	 *
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching journal article, or <code>null</code> if a matching journal article could not be found
 	 */
@@ -4528,7 +4528,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	/**
 	 * Returns the last journal article in the ordered set where DDMTemplateKey = &#63;.
 	 *
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching journal article
 	 * @throws NoSuchArticleException if a matching journal article could not be found
@@ -4559,7 +4559,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	/**
 	 * Returns the last journal article in the ordered set where DDMTemplateKey = &#63;.
 	 *
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching journal article, or <code>null</code> if a matching journal article could not be found
 	 */
@@ -4586,7 +4586,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Returns the journal articles before and after the current journal article in the ordered set where DDMTemplateKey = &#63;.
 	 *
 	 * @param id the primary key of the current journal article
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the previous, current, and next journal article
 	 * @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -4746,7 +4746,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	/**
 	 * Removes all the journal articles where DDMTemplateKey = &#63; from the database.
 	 *
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 */
 	@Override
 	public void removeByDDMTemplateKey(String DDMTemplateKey) {
@@ -4759,7 +4759,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	/**
 	 * Returns the number of journal articles where DDMTemplateKey = &#63;.
 	 *
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @return the number of matching journal articles
 	 */
 	@Override
@@ -11664,7 +11664,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Returns all the journal articles where groupId = &#63; and DDMStructureKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @return the matching journal articles
 	 */
 	@Override
@@ -11682,7 +11682,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @return the range of matching journal articles
@@ -11701,7 +11701,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -11723,7 +11723,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -11862,7 +11862,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Returns the first journal article in the ordered set where groupId = &#63; and DDMStructureKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching journal article
 	 * @throws NoSuchArticleException if a matching journal article could not be found
@@ -11898,7 +11898,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Returns the first journal article in the ordered set where groupId = &#63; and DDMStructureKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching journal article, or <code>null</code> if a matching journal article could not be found
 	 */
@@ -11920,7 +11920,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Returns the last journal article in the ordered set where groupId = &#63; and DDMStructureKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching journal article
 	 * @throws NoSuchArticleException if a matching journal article could not be found
@@ -11956,7 +11956,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Returns the last journal article in the ordered set where groupId = &#63; and DDMStructureKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching journal article, or <code>null</code> if a matching journal article could not be found
 	 */
@@ -11985,7 +11985,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param id the primary key of the current journal article
 	 * @param groupId the group ID
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the previous, current, and next journal article
 	 * @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -12150,7 +12150,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Returns all the journal articles that the user has permission to view where groupId = &#63; and DDMStructureKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @return the matching journal articles that the user has permission to view
 	 */
 	@Override
@@ -12168,7 +12168,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @return the range of matching journal articles that the user has permission to view
@@ -12187,7 +12187,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -12300,7 +12300,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param id the primary key of the current journal article
 	 * @param groupId the group ID
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the previous, current, and next journal article
 	 * @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -12505,7 +12505,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Removes all the journal articles where groupId = &#63; and DDMStructureKey = &#63; from the database.
 	 *
 	 * @param groupId the group ID
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 */
 	@Override
 	public void removeByG_DDMSK(long groupId, String DDMStructureKey) {
@@ -12519,7 +12519,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Returns the number of journal articles where groupId = &#63; and DDMStructureKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @return the number of matching journal articles
 	 */
 	@Override
@@ -12589,7 +12589,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Returns the number of journal articles that the user has permission to view where groupId = &#63; and DDMStructureKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @return the number of matching journal articles that the user has permission to view
 	 */
 	@Override
@@ -12685,7 +12685,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Returns all the journal articles where groupId = &#63; and DDMTemplateKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @return the matching journal articles
 	 */
 	@Override
@@ -12703,7 +12703,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @return the range of matching journal articles
@@ -12722,7 +12722,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -12744,7 +12744,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -12883,7 +12883,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Returns the first journal article in the ordered set where groupId = &#63; and DDMTemplateKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching journal article
 	 * @throws NoSuchArticleException if a matching journal article could not be found
@@ -12919,7 +12919,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Returns the first journal article in the ordered set where groupId = &#63; and DDMTemplateKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching journal article, or <code>null</code> if a matching journal article could not be found
 	 */
@@ -12941,7 +12941,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Returns the last journal article in the ordered set where groupId = &#63; and DDMTemplateKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching journal article
 	 * @throws NoSuchArticleException if a matching journal article could not be found
@@ -12977,7 +12977,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Returns the last journal article in the ordered set where groupId = &#63; and DDMTemplateKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching journal article, or <code>null</code> if a matching journal article could not be found
 	 */
@@ -13006,7 +13006,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param id the primary key of the current journal article
 	 * @param groupId the group ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the previous, current, and next journal article
 	 * @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -13171,7 +13171,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Returns all the journal articles that the user has permission to view where groupId = &#63; and DDMTemplateKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @return the matching journal articles that the user has permission to view
 	 */
 	@Override
@@ -13189,7 +13189,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @return the range of matching journal articles that the user has permission to view
@@ -13208,7 +13208,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * </p>
 	 *
 	 * @param groupId the group ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -13321,7 +13321,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param id the primary key of the current journal article
 	 * @param groupId the group ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the previous, current, and next journal article
 	 * @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -13526,7 +13526,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Removes all the journal articles where groupId = &#63; and DDMTemplateKey = &#63; from the database.
 	 *
 	 * @param groupId the group ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 */
 	@Override
 	public void removeByG_DDMTK(long groupId, String DDMTemplateKey) {
@@ -13540,7 +13540,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Returns the number of journal articles where groupId = &#63; and DDMTemplateKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @return the number of matching journal articles
 	 */
 	@Override
@@ -13610,7 +13610,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Returns the number of journal articles that the user has permission to view where groupId = &#63; and DDMTemplateKey = &#63;.
 	 *
 	 * @param groupId the group ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @return the number of matching journal articles that the user has permission to view
 	 */
 	@Override
@@ -18827,7 +18827,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Returns all the journal articles where classNameId = &#63; and DDMTemplateKey = &#63;.
 	 *
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @return the matching journal articles
 	 */
 	@Override
@@ -18845,7 +18845,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * </p>
 	 *
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @return the range of matching journal articles
@@ -18864,7 +18864,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * </p>
 	 *
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -18886,7 +18886,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * </p>
 	 *
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -19025,7 +19025,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Returns the first journal article in the ordered set where classNameId = &#63; and DDMTemplateKey = &#63;.
 	 *
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching journal article
 	 * @throws NoSuchArticleException if a matching journal article could not be found
@@ -19061,7 +19061,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Returns the first journal article in the ordered set where classNameId = &#63; and DDMTemplateKey = &#63;.
 	 *
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching journal article, or <code>null</code> if a matching journal article could not be found
 	 */
@@ -19083,7 +19083,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Returns the last journal article in the ordered set where classNameId = &#63; and DDMTemplateKey = &#63;.
 	 *
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching journal article
 	 * @throws NoSuchArticleException if a matching journal article could not be found
@@ -19119,7 +19119,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Returns the last journal article in the ordered set where classNameId = &#63; and DDMTemplateKey = &#63;.
 	 *
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching journal article, or <code>null</code> if a matching journal article could not be found
 	 */
@@ -19148,7 +19148,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param id the primary key of the current journal article
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the previous, current, and next journal article
 	 * @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -19313,7 +19313,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Removes all the journal articles where classNameId = &#63; and DDMTemplateKey = &#63; from the database.
 	 *
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 */
 	@Override
 	public void removeByC_DDMTK(long classNameId, String DDMTemplateKey) {
@@ -19327,7 +19327,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * Returns the number of journal articles where classNameId = &#63; and DDMTemplateKey = &#63;.
 	 *
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @return the number of matching journal articles
 	 */
 	@Override
@@ -23407,7 +23407,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param classPK the class p k
+	 * @param classPK the class pk
 	 * @return the matching journal articles
 	 */
 	@Override
@@ -23426,7 +23426,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param classPK the class p k
+	 * @param classPK the class pk
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @return the range of matching journal articles
@@ -23446,7 +23446,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param classPK the class p k
+	 * @param classPK the class pk
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -23469,7 +23469,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param classPK the class p k
+	 * @param classPK the class pk
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -23599,7 +23599,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param classPK the class p k
+	 * @param classPK the class pk
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching journal article
 	 * @throws NoSuchArticleException if a matching journal article could not be found
@@ -23638,7 +23638,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param classPK the class p k
+	 * @param classPK the class pk
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching journal article, or <code>null</code> if a matching journal article could not be found
 	 */
@@ -23660,7 +23660,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param classPK the class p k
+	 * @param classPK the class pk
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching journal article
 	 * @throws NoSuchArticleException if a matching journal article could not be found
@@ -23699,7 +23699,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param classPK the class p k
+	 * @param classPK the class pk
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching journal article, or <code>null</code> if a matching journal article could not be found
 	 */
@@ -23728,7 +23728,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * @param id the primary key of the current journal article
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param classPK the class p k
+	 * @param classPK the class pk
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the previous, current, and next journal article
 	 * @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -23885,7 +23885,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param classPK the class p k
+	 * @param classPK the class pk
 	 * @return the matching journal articles that the user has permission to view
 	 */
 	@Override
@@ -23904,7 +23904,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param classPK the class p k
+	 * @param classPK the class pk
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @return the range of matching journal articles that the user has permission to view
@@ -23924,7 +23924,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param classPK the class p k
+	 * @param classPK the class pk
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -24028,7 +24028,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * @param id the primary key of the current journal article
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param classPK the class p k
+	 * @param classPK the class pk
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the previous, current, and next journal article
 	 * @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -24225,7 +24225,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param classPK the class p k
+	 * @param classPK the class pk
 	 */
 	@Override
 	public void removeByG_C_C(long groupId, long classNameId, long classPK) {
@@ -24240,7 +24240,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param classPK the class p k
+	 * @param classPK the class pk
 	 * @return the number of matching journal articles
 	 */
 	@Override
@@ -24301,7 +24301,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param classPK the class p k
+	 * @param classPK the class pk
 	 * @return the number of matching journal articles that the user has permission to view
 	 */
 	@Override
@@ -24381,7 +24381,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @return the matching journal article
 	 * @throws NoSuchArticleException if a matching journal article could not be found
 	 */
@@ -24422,7 +24422,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @return the matching journal article, or <code>null</code> if a matching journal article could not be found
 	 */
 	@Override
@@ -24436,7 +24436,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @param retrieveFromCache whether to retrieve from the finder cache
 	 * @return the matching journal article, or <code>null</code> if a matching journal article could not be found
 	 */
@@ -24563,7 +24563,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @return the journal article that was removed
 	 */
 	@Override
@@ -24580,7 +24580,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param DDMStructureKey the d d m structure key
+	 * @param DDMStructureKey the ddm structure key
 	 * @return the number of matching journal articles
 	 */
 	@Override
@@ -24695,7 +24695,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @return the matching journal articles
 	 */
 	@Override
@@ -24714,7 +24714,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @return the range of matching journal articles
@@ -24735,7 +24735,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -24758,7 +24758,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -24903,7 +24903,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching journal article
 	 * @throws NoSuchArticleException if a matching journal article could not be found
@@ -24943,7 +24943,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching journal article, or <code>null</code> if a matching journal article could not be found
 	 */
@@ -24966,7 +24966,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching journal article
 	 * @throws NoSuchArticleException if a matching journal article could not be found
@@ -25006,7 +25006,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching journal article, or <code>null</code> if a matching journal article could not be found
 	 */
@@ -25036,7 +25036,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * @param id the primary key of the current journal article
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the previous, current, and next journal article
 	 * @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -25209,7 +25209,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @return the matching journal articles that the user has permission to view
 	 */
 	@Override
@@ -25228,7 +25228,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @return the range of matching journal articles that the user has permission to view
@@ -25249,7 +25249,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param start the lower bound of the range of journal articles
 	 * @param end the upper bound of the range of journal articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -25367,7 +25367,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 * @param id the primary key of the current journal article
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the previous, current, and next journal article
 	 * @throws NoSuchArticleException if a journal article with the primary key could not be found
@@ -25580,7 +25580,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 */
 	@Override
 	public void removeByG_C_DDMTK(long groupId, long classNameId,
@@ -25597,7 +25597,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @return the number of matching journal articles
 	 */
 	@Override
@@ -25673,7 +25673,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 	 *
 	 * @param groupId the group ID
 	 * @param classNameId the class name ID
-	 * @param DDMTemplateKey the d d m template key
+	 * @param DDMTemplateKey the ddm template key
 	 * @return the number of matching journal articles that the user has permission to view
 	 */
 	@Override
@@ -31870,8 +31870,278 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 
 		finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITH_PAGINATION);
 
-		if (isNew || !JournalArticleModelImpl.COLUMN_BITMASK_ENABLED) {
+		if (!JournalArticleModelImpl.COLUMN_BITMASK_ENABLED) {
 			finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION);
+		}
+		else
+		 if (isNew) {
+			Object[] args = new Object[] { journalArticleModelImpl.getUuid() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_UUID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_UUID,
+				args);
+
+			args = new Object[] {
+					journalArticleModelImpl.getUuid(),
+					journalArticleModelImpl.getCompanyId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_UUID_C, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_UUID_C,
+				args);
+
+			args = new Object[] { journalArticleModelImpl.getResourcePrimKey() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_RESOURCEPRIMKEY, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_RESOURCEPRIMKEY,
+				args);
+
+			args = new Object[] { journalArticleModelImpl.getGroupId() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_GROUPID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_GROUPID,
+				args);
+
+			args = new Object[] { journalArticleModelImpl.getCompanyId() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_COMPANYID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_COMPANYID,
+				args);
+
+			args = new Object[] { journalArticleModelImpl.getDDMStructureKey() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_DDMSTRUCTUREKEY, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_DDMSTRUCTUREKEY,
+				args);
+
+			args = new Object[] { journalArticleModelImpl.getDDMTemplateKey() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_DDMTEMPLATEKEY, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_DDMTEMPLATEKEY,
+				args);
+
+			args = new Object[] { journalArticleModelImpl.getLayoutUuid() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_LAYOUTUUID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_LAYOUTUUID,
+				args);
+
+			args = new Object[] { journalArticleModelImpl.getSmallImageId() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_SMALLIMAGEID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_SMALLIMAGEID,
+				args);
+
+			args = new Object[] {
+					journalArticleModelImpl.getResourcePrimKey(),
+					journalArticleModelImpl.getIndexable()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_R_I, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_R_I,
+				args);
+
+			args = new Object[] {
+					journalArticleModelImpl.getResourcePrimKey(),
+					journalArticleModelImpl.getStatus()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_R_ST, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_R_ST,
+				args);
+
+			args = new Object[] {
+					journalArticleModelImpl.getGroupId(),
+					journalArticleModelImpl.getUserId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_U, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_U,
+				args);
+
+			args = new Object[] {
+					journalArticleModelImpl.getGroupId(),
+					journalArticleModelImpl.getFolderId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_F, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_F,
+				args);
+
+			args = new Object[] {
+					journalArticleModelImpl.getGroupId(),
+					journalArticleModelImpl.getArticleId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_A, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_A,
+				args);
+
+			args = new Object[] {
+					journalArticleModelImpl.getGroupId(),
+					journalArticleModelImpl.getUrlTitle()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_UT, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_UT,
+				args);
+
+			args = new Object[] {
+					journalArticleModelImpl.getGroupId(),
+					journalArticleModelImpl.getDDMStructureKey()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_DDMSK, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_DDMSK,
+				args);
+
+			args = new Object[] {
+					journalArticleModelImpl.getGroupId(),
+					journalArticleModelImpl.getDDMTemplateKey()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_DDMTK, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_DDMTK,
+				args);
+
+			args = new Object[] {
+					journalArticleModelImpl.getGroupId(),
+					journalArticleModelImpl.getLayoutUuid()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_L, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_L,
+				args);
+
+			args = new Object[] {
+					journalArticleModelImpl.getGroupId(),
+					journalArticleModelImpl.getStatus()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_ST, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_ST,
+				args);
+
+			args = new Object[] {
+					journalArticleModelImpl.getCompanyId(),
+					journalArticleModelImpl.getVersion()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_C_V, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_C_V,
+				args);
+
+			args = new Object[] {
+					journalArticleModelImpl.getCompanyId(),
+					journalArticleModelImpl.getStatus()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_C_ST, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_C_ST,
+				args);
+
+			args = new Object[] {
+					journalArticleModelImpl.getClassNameId(),
+					journalArticleModelImpl.getDDMTemplateKey()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_C_DDMTK, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_C_DDMTK,
+				args);
+
+			args = new Object[] {
+					journalArticleModelImpl.getResourcePrimKey(),
+					journalArticleModelImpl.getIndexable(),
+					journalArticleModelImpl.getStatus()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_R_I_S, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_R_I_S,
+				args);
+
+			args = new Object[] {
+					journalArticleModelImpl.getGroupId(),
+					journalArticleModelImpl.getUserId(),
+					journalArticleModelImpl.getClassNameId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_U_C, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_U_C,
+				args);
+
+			args = new Object[] {
+					journalArticleModelImpl.getGroupId(),
+					journalArticleModelImpl.getFolderId(),
+					journalArticleModelImpl.getStatus()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_F_ST, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_F_ST,
+				args);
+
+			args = new Object[] {
+					journalArticleModelImpl.getGroupId(),
+					journalArticleModelImpl.getClassNameId(),
+					journalArticleModelImpl.getClassPK()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_C_C, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_C_C,
+				args);
+
+			args = new Object[] {
+					journalArticleModelImpl.getGroupId(),
+					journalArticleModelImpl.getClassNameId(),
+					journalArticleModelImpl.getDDMTemplateKey()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_C_DDMTK, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_C_DDMTK,
+				args);
+
+			args = new Object[] {
+					journalArticleModelImpl.getGroupId(),
+					journalArticleModelImpl.getClassNameId(),
+					journalArticleModelImpl.getLayoutUuid()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_C_L, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_C_L,
+				args);
+
+			args = new Object[] {
+					journalArticleModelImpl.getGroupId(),
+					journalArticleModelImpl.getArticleId(),
+					journalArticleModelImpl.getStatus()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_A_ST, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_A_ST,
+				args);
+
+			args = new Object[] {
+					journalArticleModelImpl.getGroupId(),
+					journalArticleModelImpl.getUrlTitle(),
+					journalArticleModelImpl.getStatus()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_UT_ST, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_UT_ST,
+				args);
+
+			args = new Object[] {
+					journalArticleModelImpl.getCompanyId(),
+					journalArticleModelImpl.getVersion(),
+					journalArticleModelImpl.getStatus()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_C_V_ST, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_C_V_ST,
+				args);
+
+			finderCache.removeResult(FINDER_PATH_COUNT_ALL, FINDER_ARGS_EMPTY);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_ALL,
+				FINDER_ARGS_EMPTY);
 		}
 
 		else {

--- a/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticleResourcePersistenceImpl.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticleResourcePersistenceImpl.java
@@ -2578,8 +2578,37 @@ public class JournalArticleResourcePersistenceImpl extends BasePersistenceImpl<J
 
 		finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITH_PAGINATION);
 
-		if (isNew || !JournalArticleResourceModelImpl.COLUMN_BITMASK_ENABLED) {
+		if (!JournalArticleResourceModelImpl.COLUMN_BITMASK_ENABLED) {
 			finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION);
+		}
+		else
+		 if (isNew) {
+			Object[] args = new Object[] {
+					journalArticleResourceModelImpl.getUuid()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_UUID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_UUID,
+				args);
+
+			args = new Object[] {
+					journalArticleResourceModelImpl.getUuid(),
+					journalArticleResourceModelImpl.getCompanyId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_UUID_C, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_UUID_C,
+				args);
+
+			args = new Object[] { journalArticleResourceModelImpl.getGroupId() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_GROUPID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_GROUPID,
+				args);
+
+			finderCache.removeResult(FINDER_PATH_COUNT_ALL, FINDER_ARGS_EMPTY);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_ALL,
+				FINDER_ARGS_EMPTY);
 		}
 
 		else {

--- a/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalContentSearchPersistenceImpl.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalContentSearchPersistenceImpl.java
@@ -4914,8 +4914,77 @@ public class JournalContentSearchPersistenceImpl extends BasePersistenceImpl<Jou
 
 		finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITH_PAGINATION);
 
-		if (isNew || !JournalContentSearchModelImpl.COLUMN_BITMASK_ENABLED) {
+		if (!JournalContentSearchModelImpl.COLUMN_BITMASK_ENABLED) {
 			finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION);
+		}
+		else
+		 if (isNew) {
+			Object[] args = new Object[] {
+					journalContentSearchModelImpl.getPortletId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_PORTLETID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_PORTLETID,
+				args);
+
+			args = new Object[] { journalContentSearchModelImpl.getArticleId() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_ARTICLEID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_ARTICLEID,
+				args);
+
+			args = new Object[] {
+					journalContentSearchModelImpl.getGroupId(),
+					journalContentSearchModelImpl.getPrivateLayout()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_P, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_P,
+				args);
+
+			args = new Object[] {
+					journalContentSearchModelImpl.getGroupId(),
+					journalContentSearchModelImpl.getArticleId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_A, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_A,
+				args);
+
+			args = new Object[] {
+					journalContentSearchModelImpl.getGroupId(),
+					journalContentSearchModelImpl.getPrivateLayout(),
+					journalContentSearchModelImpl.getLayoutId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_P_L, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_P_L,
+				args);
+
+			args = new Object[] {
+					journalContentSearchModelImpl.getGroupId(),
+					journalContentSearchModelImpl.getPrivateLayout(),
+					journalContentSearchModelImpl.getArticleId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_P_A, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_P_A,
+				args);
+
+			args = new Object[] {
+					journalContentSearchModelImpl.getGroupId(),
+					journalContentSearchModelImpl.getPrivateLayout(),
+					journalContentSearchModelImpl.getLayoutId(),
+					journalContentSearchModelImpl.getPortletId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_P_L_P, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_P_L_P,
+				args);
+
+			finderCache.removeResult(FINDER_PATH_COUNT_ALL, FINDER_ARGS_EMPTY);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_ALL,
+				FINDER_ARGS_EMPTY);
 		}
 
 		else {

--- a/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalFeedPersistenceImpl.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalFeedPersistenceImpl.java
@@ -2914,8 +2914,35 @@ public class JournalFeedPersistenceImpl extends BasePersistenceImpl<JournalFeed>
 
 		finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITH_PAGINATION);
 
-		if (isNew || !JournalFeedModelImpl.COLUMN_BITMASK_ENABLED) {
+		if (!JournalFeedModelImpl.COLUMN_BITMASK_ENABLED) {
 			finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION);
+		}
+		else
+		 if (isNew) {
+			Object[] args = new Object[] { journalFeedModelImpl.getUuid() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_UUID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_UUID,
+				args);
+
+			args = new Object[] {
+					journalFeedModelImpl.getUuid(),
+					journalFeedModelImpl.getCompanyId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_UUID_C, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_UUID_C,
+				args);
+
+			args = new Object[] { journalFeedModelImpl.getGroupId() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_GROUPID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_GROUPID,
+				args);
+
+			finderCache.removeResult(FINDER_PATH_COUNT_ALL, FINDER_ARGS_EMPTY);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_ALL,
+				FINDER_ARGS_EMPTY);
 		}
 
 		else {

--- a/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalFolderPersistenceImpl.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalFolderPersistenceImpl.java
@@ -7632,8 +7632,60 @@ public class JournalFolderPersistenceImpl extends BasePersistenceImpl<JournalFol
 
 		finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITH_PAGINATION);
 
-		if (isNew || !JournalFolderModelImpl.COLUMN_BITMASK_ENABLED) {
+		if (!JournalFolderModelImpl.COLUMN_BITMASK_ENABLED) {
 			finderCache.clearCache(FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION);
+		}
+		else
+		 if (isNew) {
+			Object[] args = new Object[] { journalFolderModelImpl.getUuid() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_UUID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_UUID,
+				args);
+
+			args = new Object[] {
+					journalFolderModelImpl.getUuid(),
+					journalFolderModelImpl.getCompanyId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_UUID_C, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_UUID_C,
+				args);
+
+			args = new Object[] { journalFolderModelImpl.getGroupId() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_GROUPID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_GROUPID,
+				args);
+
+			args = new Object[] { journalFolderModelImpl.getCompanyId() };
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_COMPANYID, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_COMPANYID,
+				args);
+
+			args = new Object[] {
+					journalFolderModelImpl.getGroupId(),
+					journalFolderModelImpl.getParentFolderId()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_P, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_P,
+				args);
+
+			args = new Object[] {
+					journalFolderModelImpl.getGroupId(),
+					journalFolderModelImpl.getParentFolderId(),
+					journalFolderModelImpl.getStatus()
+				};
+
+			finderCache.removeResult(FINDER_PATH_COUNT_BY_G_P_S, args);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_P_S,
+				args);
+
+			finderCache.removeResult(FINDER_PATH_COUNT_ALL, FINDER_ARGS_EMPTY);
+			finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_ALL,
+				FINDER_ARGS_EMPTY);
 		}
 
 		else {

--- a/journal-service/src/main/java/com/liferay/journal/transformer/PropertiesTransformerListener.java
+++ b/journal-service/src/main/java/com/liferay/journal/transformer/PropertiesTransformerListener.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Component;
 /**
  * @author     Brian Wing Shun Chan
  * @deprecated As of 4.0.0, replaced by {@link
- *             #com.liferay.journal.properties.transformer.listener.JournalPropertiesTransformerListener}
+ *             #com.liferay.journal.properties.transformer.listener.internal.JournalPropertiesTransformerListener}
  */
 @Component(
 	immediate = true,

--- a/journal-service/src/main/java/com/liferay/journal/transformer/PropertiesTransformerListener.java
+++ b/journal-service/src/main/java/com/liferay/journal/transformer/PropertiesTransformerListener.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Component;
 /**
  * @author     Brian Wing Shun Chan
  * @deprecated As of 4.0.0, replaced by {@link
- *             #com.liferay.journal.properties.trasnformer.listener.JournalPropertiesTransformerListener}
+ *             #com.liferay.journal.properties.transformer.listener.JournalPropertiesTransformerListener}
  */
 @Component(
 	immediate = true,

--- a/journal-service/src/main/resources/com/liferay/journal/internal/upgrade/v1_1_0/dependencies/update.sql
+++ b/journal-service/src/main/resources/com/liferay/journal/internal/upgrade/v1_1_0/dependencies/update.sql
@@ -7,6 +7,8 @@ create table JournalArticleLocalization (
 	languageId VARCHAR(75) null
 );
 
+create unique index IX_ACF2560A on JournalArticleLocalization (articlePK, languageId[$COLUMN_LENGTH:75$]);
+
 alter table JournalArticle add defaultLanguageId VARCHAR(75) null;
 
 COMMIT_TRANSACTION;

--- a/journal-terms-of-use/bnd.bnd
+++ b/journal-terms-of-use/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Journal Terms Of Use
 Bundle-SymbolicName: com.liferay.journal.terms.of.use
-Bundle-Version: 2.0.22
+Bundle-Version: 2.0.23
 Import-Package:\
 	com.liferay.portal.kernel.exception;version="[7.0.0,8.0.0)",\
 	com.liferay.portal.kernel.model;version="[1.0.0,2.0.0)",\

--- a/journal-terms-of-use/bnd.bnd
+++ b/journal-terms-of-use/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Journal Terms Of Use
 Bundle-SymbolicName: com.liferay.journal.terms.of.use
-Bundle-Version: 2.0.23
+Bundle-Version: 2.0.24
 Import-Package:\
 	com.liferay.portal.kernel.exception;version="[7.0.0,8.0.0)",\
 	com.liferay.portal.kernel.model;version="[1.0.0,2.0.0)",\

--- a/journal-web/bnd.bnd
+++ b/journal-web/bnd.bnd
@@ -9,5 +9,7 @@ Export-Package:\
 Liferay-JS-Config: /META-INF/resources/js/config.js
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title: Web Content
-Require-Capability: osgi.extender;filter:="(&(osgi.extender=jsp.taglib)(uri=http://liferay.com/tld/soy))"
+Require-Capability:\
+	osgi.extender;\
+		filter:="(&(osgi.extender=jsp.taglib)(uri=http://liferay.com/tld/soy))"
 Web-ContextPath: /journal-web

--- a/journal-web/bnd.bnd
+++ b/journal-web/bnd.bnd
@@ -9,4 +9,5 @@ Export-Package:\
 Liferay-JS-Config: /META-INF/resources/js/config.js
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title: Web Content
+Require-Capability: osgi.extender;filter:="(&(osgi.extender=jsp.taglib)(uri=http://liferay.com/tld/soy))"
 Web-ContextPath: /journal-web

--- a/journal-web/build.gradle
+++ b/journal-web/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.rss.util", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.trash.taglib", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.23.0-20170223.232845-1"
 	provided group: "com.liferay.portal", name: "com.liferay.util.java", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "2.2.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"

--- a/journal-web/build.gradle
+++ b/journal-web/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.dynamic.data.mapping.taglib", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.expando.taglib", version: "1.0.0-20161221.224748-2"
 	provided group: "com.liferay", name: "com.liferay.frontend.taglib", version: "2.1.0-20160908.163901-1"
+	provided group: "com.liferay", name: "com.liferay.frontend.taglib.soy", version: "1.0.4-20170214.042916-1"
 	provided group: "com.liferay", name: "com.liferay.item.selector.api", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.item.selector.criteria.api", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.layout.item.selector.api", version: "1.0.0"

--- a/journal-web/build.gradle
+++ b/journal-web/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.rss.util", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.trash.taglib", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.7.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.util.java", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "2.2.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"

--- a/journal-web/npm-shrinkwrap.json
+++ b/journal-web/npm-shrinkwrap.json
@@ -2,13 +2,13 @@
 	"dependencies": {
 		"abbrev": {
 			"from": "abbrev@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-			"version": "1.0.9"
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+			"version": "1.1.0"
 		},
 		"ansi-regex": {
 			"from": "ansi-regex@>=2.0.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-			"version": "2.0.0"
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"version": "2.1.1"
 		},
 		"ansi-styles": {
 			"from": "ansi-styles@>=2.2.1 <3.0.0",
@@ -35,11 +35,6 @@
 			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
 			"version": "1.0.0"
 		},
-		"array-find-index": {
-			"from": "array-find-index@>=1.0.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz",
-			"version": "1.0.1"
-		},
 		"array-uniq": {
 			"from": "array-uniq@>=1.0.2 <2.0.0",
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
@@ -62,13 +57,13 @@
 		},
 		"beeper": {
 			"from": "beeper@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
-			"version": "1.1.0"
+			"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+			"version": "1.1.1"
 		},
 		"bluebird": {
 			"from": "bluebird@>=3.0.6 <4.0.0",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.3.tgz",
-			"version": "3.4.3"
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+			"version": "3.4.7"
 		},
 		"bootstrap": {
 			"from": "bootstrap@>=3.3.6 <4.0.0",
@@ -84,8 +79,8 @@
 			"dependencies": {
 				"object-assign": {
 					"from": "object-assign@>=4.0.1 <5.0.0",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-					"version": "4.1.0"
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"version": "4.1.1"
 				}
 			},
 			"from": "boxen@>=0.3.1 <0.4.0",
@@ -106,21 +101,6 @@
 			"from": "buffer-shims@>=1.0.0 <2.0.0",
 			"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
 			"version": "1.0.0"
-		},
-		"builtin-modules": {
-			"from": "builtin-modules@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"version": "1.1.1"
-		},
-		"camelcase": {
-			"from": "camelcase@>=2.0.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-			"version": "2.1.1"
-		},
-		"camelcase-keys": {
-			"from": "camelcase-keys@>=2.0.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-			"version": "2.1.0"
 		},
 		"capture-stack-trace": {
 			"from": "capture-stack-trace@>=1.0.0 <2.0.0",
@@ -144,8 +124,8 @@
 		},
 		"code-point-at": {
 			"from": "code-point-at@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-			"version": "1.0.0"
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"version": "1.1.0"
 		},
 		"commander": {
 			"from": "commander@>=2.8.1 <3.0.0",
@@ -159,20 +139,20 @@
 		},
 		"config-chain": {
 			"from": "config-chain@>=1.1.5 <1.2.0",
-			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
-			"version": "1.1.10"
+			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+			"version": "1.1.11"
 		},
 		"configstore": {
 			"dependencies": {
 				"object-assign": {
 					"from": "object-assign@>=4.0.1 <5.0.0",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-					"version": "4.1.0"
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"version": "4.1.1"
 				}
 			},
 			"from": "configstore@>=2.0.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/configstore/-/configstore-2.0.0.tgz",
-			"version": "2.0.0"
+			"resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
+			"version": "2.1.0"
 		},
 		"core-util-is": {
 			"from": "core-util-is@>=1.0.0 <1.1.0",
@@ -184,20 +164,10 @@
 			"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
 			"version": "3.0.2"
 		},
-		"currently-unhandled": {
-			"from": "currently-unhandled@>=0.4.1 <0.5.0",
-			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-			"version": "0.4.1"
-		},
 		"dateformat": {
-			"from": "dateformat@>=1.0.11 <2.0.0",
-			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-			"version": "1.0.12"
-		},
-		"decamelize": {
-			"from": "decamelize@>=1.1.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"version": "1.2.0"
+			"from": "dateformat@>=2.0.0 <3.0.0",
+			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+			"version": "2.0.0"
 		},
 		"deep-extend": {
 			"from": "deep-extend@>=0.4.0 <0.5.0",
@@ -220,16 +190,35 @@
 			"version": "0.1.0"
 		},
 		"dot-prop": {
-			"from": "dot-prop@>=2.3.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-2.4.0.tgz",
-			"version": "2.4.0"
+			"from": "dot-prop@>=3.0.0 <4.0.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+			"version": "3.0.0"
 		},
 		"duplexer2": {
 			"from": "duplexer2@0.0.2",
 			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
 			"version": "0.0.2"
 		},
+		"editorconfig": {
+			"dependencies": {
+				"lru-cache": {
+					"from": "lru-cache@>=3.2.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+					"version": "3.2.0"
+				}
+			},
+			"from": "editorconfig@>=0.13.2 <0.14.0",
+			"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.2.tgz",
+			"version": "0.13.2"
+		},
 		"end-of-stream": {
+			"dependencies": {
+				"once": {
+					"from": "once@>=1.3.0 <1.4.0",
+					"resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+					"version": "1.3.3"
+				}
+			},
 			"from": "end-of-stream@>=0.1.5 <0.2.0",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
 			"version": "0.1.5"
@@ -281,8 +270,8 @@
 		},
 		"fancy-log": {
 			"from": "fancy-log@>=1.1.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
-			"version": "1.2.0"
+			"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+			"version": "1.3.0"
 		},
 		"filename-regex": {
 			"from": "filename-regex@>=2.0.0 <3.0.0",
@@ -304,27 +293,15 @@
 			"resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
 			"version": "0.1.1"
 		},
-		"find-up": {
-			"from": "find-up@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-			"version": "1.1.2"
-		},
 		"findup-sync": {
 			"from": "findup-sync@>=0.4.2 <0.5.0",
-			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.2.tgz",
-			"version": "0.4.2"
+			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
+			"version": "0.4.3"
 		},
 		"fined": {
-			"dependencies": {
-				"lodash.isarray": {
-					"from": "lodash.isarray@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-4.0.0.tgz",
-					"version": "4.0.0"
-				}
-			},
 			"from": "fined@>=1.0.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/fined/-/fined-1.0.1.tgz",
-			"version": "1.0.1"
+			"resolved": "https://registry.npmjs.org/fined/-/fined-1.0.2.tgz",
+			"version": "1.0.2"
 		},
 		"first-chunk-stream": {
 			"from": "first-chunk-stream@>=1.0.0 <2.0.0",
@@ -337,14 +314,14 @@
 			"version": "0.3.2"
 		},
 		"for-in": {
-			"from": "for-in@>=0.1.5 <0.2.0",
-			"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz",
-			"version": "0.1.5"
+			"from": "for-in@>=1.0.1 <2.0.0",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"version": "1.0.2"
 		},
 		"for-own": {
-			"from": "for-own@>=0.1.3 <0.2.0",
-			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-			"version": "0.1.4"
+			"from": "for-own@>=0.1.4 <0.2.0",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+			"version": "0.1.5"
 		},
 		"foreachasync": {
 			"from": "foreachasync@>=3.0.0 <4.0.0",
@@ -371,15 +348,10 @@
 			"resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
 			"version": "0.5.2"
 		},
-		"get-stdin": {
-			"from": "get-stdin@>=4.0.1 <5.0.0",
-			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-			"version": "4.0.1"
-		},
 		"glob": {
 			"from": "glob@>=7.0.5 <8.0.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
-			"version": "7.0.6"
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+			"version": "7.1.1"
 		},
 		"glob-base": {
 			"from": "glob-base@>=0.3.0 <0.4.0",
@@ -435,8 +407,8 @@
 		},
 		"global-prefix": {
 			"from": "global-prefix@>=0.1.4 <0.2.0",
-			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.4.tgz",
-			"version": "0.1.4"
+			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+			"version": "0.1.5"
 		},
 		"globule": {
 			"dependencies": {
@@ -484,23 +456,23 @@
 				},
 				"object-assign": {
 					"from": "object-assign@>=4.0.1 <5.0.0",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-					"version": "4.1.0"
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"version": "4.1.1"
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=2.0.5 <3.0.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-					"version": "2.1.5"
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz",
+					"version": "2.2.3"
 				}
 			},
 			"from": "got@>=5.0.0 <6.0.0",
-			"resolved": "https://registry.npmjs.org/got/-/got-5.6.0.tgz",
-			"version": "5.6.0"
+			"resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
+			"version": "5.7.1"
 		},
 		"graceful-fs": {
 			"from": "graceful-fs@>=4.1.2 <5.0.0",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
-			"version": "4.1.6"
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+			"version": "4.1.11"
 		},
 		"graceful-readlink": {
 			"from": "graceful-readlink@>=1.0.0",
@@ -514,8 +486,8 @@
 		},
 		"gulp-util": {
 			"from": "gulp-util@>=3.0.0 <4.0.0",
-			"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-			"version": "3.0.7"
+			"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+			"version": "3.0.8"
 		},
 		"gulplog": {
 			"from": "gulplog@>=1.0.0 <2.0.0",
@@ -532,35 +504,30 @@
 			"resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
 			"version": "0.1.0"
 		},
-		"hosted-git-info": {
-			"from": "hosted-git-info@>=2.1.4 <3.0.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-			"version": "2.1.5"
+		"homedir-polyfill": {
+			"from": "homedir-polyfill@>=1.0.0 <2.0.0",
+			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+			"version": "1.0.1"
 		},
 		"html2incdom": {
 			"from": "html2incdom@>=0.1.1 <0.2.0",
-			"resolved": "https://registry.npmjs.org/html2incdom/-/html2incdom-0.1.7.tgz",
-			"version": "0.1.7"
+			"resolved": "https://registry.npmjs.org/html2incdom/-/html2incdom-0.1.8.tgz",
+			"version": "0.1.8"
 		},
 		"imurmurhash": {
 			"from": "imurmurhash@>=0.1.4 <0.2.0",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"version": "0.1.4"
 		},
-		"indent-string": {
-			"from": "indent-string@>=2.1.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-			"version": "2.1.0"
-		},
 		"inflight": {
 			"from": "inflight@>=1.0.4 <2.0.0",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-			"version": "1.0.5"
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"version": "1.0.6"
 		},
 		"inherits": {
 			"from": "inherits@>=2.0.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-			"version": "2.0.1"
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"version": "2.0.3"
 		},
 		"ini": {
 			"from": "ini@>=1.3.4 <2.0.0",
@@ -573,16 +540,9 @@
 			"version": "1.0.1"
 		},
 		"is-absolute": {
-			"dependencies": {
-				"is-windows": {
-					"from": "is-windows@>=0.1.1 <0.2.0",
-					"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.1.1.tgz",
-					"version": "0.1.1"
-				}
-			},
 			"from": "is-absolute@>=0.2.3 <0.3.0",
-			"resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.5.tgz",
-			"version": "0.2.5"
+			"resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
+			"version": "0.2.6"
 		},
 		"is-arrayish": {
 			"from": "is-arrayish@>=0.2.1 <0.3.0",
@@ -593,11 +553,6 @@
 			"from": "is-buffer@>=1.0.2 <2.0.0",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
 			"version": "1.1.4"
-		},
-		"is-builtin-module": {
-			"from": "is-builtin-module@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-			"version": "1.0.0"
 		},
 		"is-dotfile": {
 			"from": "is-dotfile@>=1.0.0 <2.0.0",
@@ -621,8 +576,8 @@
 		},
 		"is-finite": {
 			"from": "is-finite@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-			"version": "1.0.1"
+			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+			"version": "1.0.2"
 		},
 		"is-fullwidth-code-point": {
 			"from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
@@ -648,11 +603,6 @@
 			"from": "is-obj@>=1.0.0 <2.0.0",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"version": "1.0.1"
-		},
-		"is-plain-obj": {
-			"from": "is-plain-obj@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"version": "1.1.0"
 		},
 		"is-posix-bracket": {
 			"from": "is-posix-bracket@>=0.1.0 <0.2.0",
@@ -686,8 +636,8 @@
 		},
 		"is-unc-path": {
 			"from": "is-unc-path@>=0.1.1 <0.2.0",
-			"resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.1.tgz",
-			"version": "0.1.1"
+			"resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
+			"version": "0.1.2"
 		},
 		"is-utf8": {
 			"from": "is-utf8@>=0.2.0 <0.3.0",
@@ -723,13 +673,13 @@
 		},
 		"js-beautify": {
 			"from": "js-beautify@>=1.5.10 <2.0.0",
-			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.3.tgz",
-			"version": "1.6.3"
+			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.11.tgz",
+			"version": "1.6.11"
 		},
 		"jsonfile": {
 			"from": "jsonfile@>=2.1.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.1.tgz",
-			"version": "2.3.1"
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+			"version": "2.4.0"
 		},
 		"jsstana": {
 			"from": "jsstana@>=0.1.5 <0.2.0",
@@ -738,13 +688,13 @@
 		},
 		"kind-of": {
 			"from": "kind-of@>=3.0.2 <4.0.0",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-			"version": "3.0.4"
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
+			"version": "3.1.0"
 		},
 		"klaw": {
 			"from": "klaw@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz",
-			"version": "1.3.0"
+			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+			"version": "1.3.1"
 		},
 		"latest-version": {
 			"from": "latest-version@>=2.0.0 <3.0.0",
@@ -757,19 +707,14 @@
 			"version": "1.0.5"
 		},
 		"liferay-module-config-generator": {
-			"from": "liferay-module-config-generator@>=1.1.10 <2.0.0",
-			"resolved": "https://registry.npmjs.org/liferay-module-config-generator/-/liferay-module-config-generator-1.1.10.tgz",
-			"version": "1.1.10"
+			"from": "liferay-module-config-generator@>=1.2.1 <2.0.0",
+			"resolved": "https://registry.npmjs.org/liferay-module-config-generator/-/liferay-module-config-generator-1.2.1.tgz",
+			"version": "1.2.1"
 		},
 		"liftoff": {
 			"from": "liftoff@>=2.1.0 <3.0.0",
 			"resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
 			"version": "2.3.0"
-		},
-		"load-json-file": {
-			"from": "load-json-file@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-			"version": "1.1.0"
 		},
 		"lodash": {
 			"from": "lodash@>=1.0.1 <1.1.0",
@@ -886,11 +831,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
 			"version": "3.1.1"
 		},
-		"loud-rejection": {
-			"from": "loud-rejection@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-			"version": "1.6.0"
-		},
 		"lowercase-keys": {
 			"from": "lowercase-keys@>=1.0.0 <2.0.0",
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
@@ -906,27 +846,10 @@
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
 			"version": "0.2.2"
 		},
-		"map-obj": {
-			"from": "map-obj@>=1.0.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-			"version": "1.0.1"
-		},
-		"meow": {
-			"dependencies": {
-				"object-assign": {
-					"from": "object-assign@>=4.0.1 <5.0.0",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-					"version": "4.1.0"
-				}
-			},
-			"from": "meow@>=3.3.0 <4.0.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-			"version": "3.7.0"
-		},
 		"metal": {
 			"from": "metal@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/metal/-/metal-1.0.4.tgz",
-			"version": "1.0.4"
+			"resolved": "https://registry.npmjs.org/metal/-/metal-1.0.5.tgz",
+			"version": "1.0.5"
 		},
 		"metal-affix": {
 			"from": "metal-affix@>=1.0.0-rc.1 <2.0.0",
@@ -955,6 +878,11 @@
 		},
 		"metal-cli": {
 			"dependencies": {
+				"acorn": {
+					"from": "acorn@>=4.0.0 <5.0.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz",
+					"version": "4.0.3"
+				},
 				"amdefine": {
 					"from": "amdefine@>=0.0.4",
 					"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
@@ -987,8 +915,8 @@
 				},
 				"array-find-index": {
 					"from": "array-find-index@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"array-uniq": {
 					"from": "array-uniq@>=1.0.2 <2.0.0",
@@ -1000,27 +928,32 @@
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 					"version": "0.2.1"
 				},
+				"atob": {
+					"from": "atob@>=1.1.0 <1.2.0",
+					"resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
+					"version": "1.1.3"
+				},
 				"babel-code-frame": {
-					"from": "babel-code-frame@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.11.0.tgz",
-					"version": "6.11.0"
+					"from": "babel-code-frame@>=6.16.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
+					"version": "6.16.0"
 				},
 				"babel-core": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.14.0.tgz",
-							"version": "4.14.0"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
+							"version": "4.16.4"
 						},
 						"minimatch": {
 							"from": "minimatch@>=3.0.2 <4.0.0",
-							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
-							"version": "3.0.2"
+							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+							"version": "3.0.3"
 						}
 					},
-					"from": "babel-core@>=6.11.4 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.11.4.tgz",
-					"version": "6.11.4"
+					"from": "babel-core@>=6.3.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.17.0.tgz",
+					"version": "6.17.0"
 				},
 				"babel-deps": {
 					"from": "babel-deps@>=2.0.0 <3.0.0",
@@ -1029,20 +962,25 @@
 				},
 				"babel-generator": {
 					"dependencies": {
+						"jsesc": {
+							"from": "jsesc@>=1.3.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+							"version": "1.3.0"
+						},
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.14.0.tgz",
-							"version": "4.14.0"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
+							"version": "4.16.4"
 						}
 					},
-					"from": "babel-generator@>=6.11.4 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.11.4.tgz",
-					"version": "6.11.4"
+					"from": "babel-generator@>=6.17.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.17.0.tgz",
+					"version": "6.17.0"
 				},
 				"babel-globals": {
 					"from": "babel-globals@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/babel-globals/-/babel-globals-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/babel-globals/-/babel-globals-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"babel-helper-call-delegate": {
 					"from": "babel-helper-call-delegate@>=6.8.0 <7.0.0",
@@ -1053,8 +991,8 @@
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.14.0.tgz",
-							"version": "4.14.0"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
+							"version": "4.16.4"
 						}
 					},
 					"from": "babel-helper-define-map@>=6.9.0 <7.0.0",
@@ -1085,8 +1023,8 @@
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.14.0.tgz",
-							"version": "4.14.0"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
+							"version": "4.16.4"
 						}
 					},
 					"from": "babel-helper-regex@>=6.8.0 <7.0.0",
@@ -1094,14 +1032,14 @@
 					"version": "6.9.0"
 				},
 				"babel-helper-replace-supers": {
-					"from": "babel-helper-replace-supers@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-replace-supers@>=6.14.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.16.0.tgz",
+					"version": "6.16.0"
 				},
 				"babel-helpers": {
-					"from": "babel-helpers@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helpers@>=6.16.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz",
+					"version": "6.16.0"
 				},
 				"babel-messages": {
 					"from": "babel-messages@>=6.8.0 <7.0.0",
@@ -1131,13 +1069,9 @@
 					"version": "6.3.13"
 				},
 				"babel-plugin-globals": {
-					"from": "babel-plugin-globals@>=1.0.1 <2.0.0",
-					"version": "1.1.1"
-				},
-				"babel-plugin-syntax-async-functions": {
-					"from": "babel-plugin-syntax-async-functions@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-globals@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-globals/-/babel-plugin-globals-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"babel-plugin-transform-es2015-arrow-functions": {
 					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
@@ -1153,18 +1087,18 @@
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.14.0.tgz",
-							"version": "4.14.0"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
+							"version": "4.16.4"
 						}
 					},
-					"from": "babel-plugin-transform-es2015-block-scoping@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.10.1.tgz",
-					"version": "6.10.1"
+					"from": "babel-plugin-transform-es2015-block-scoping@>=6.14.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.15.0.tgz",
+					"version": "6.15.0"
 				},
 				"babel-plugin-transform-es2015-classes": {
-					"from": "babel-plugin-transform-es2015-classes@>=6.2.2 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-plugin-transform-es2015-classes@>=6.14.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.14.0.tgz",
+					"version": "6.14.0"
 				},
 				"babel-plugin-transform-es2015-computed-properties": {
 					"from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
@@ -1172,9 +1106,9 @@
 					"version": "6.8.0"
 				},
 				"babel-plugin-transform-es2015-destructuring": {
-					"from": "babel-plugin-transform-es2015-destructuring@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-plugin-transform-es2015-destructuring@>=6.16.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.16.0.tgz",
+					"version": "6.16.0"
 				},
 				"babel-plugin-transform-es2015-duplicate-keys": {
 					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
@@ -1203,8 +1137,18 @@
 				},
 				"babel-plugin-transform-es2015-modules-commonjs": {
 					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.11.5.tgz",
-					"version": "6.11.5"
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.16.0.tgz",
+					"version": "6.16.0"
+				},
+				"babel-plugin-transform-es2015-modules-systemjs": {
+					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.14.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.14.0.tgz",
+					"version": "6.14.0"
+				},
+				"babel-plugin-transform-es2015-modules-umd": {
+					"from": "babel-plugin-transform-es2015-modules-umd@>=6.12.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.12.0.tgz",
+					"version": "6.12.0"
 				},
 				"babel-plugin-transform-es2015-object-super": {
 					"from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
@@ -1212,9 +1156,9 @@
 					"version": "6.8.0"
 				},
 				"babel-plugin-transform-es2015-parameters": {
-					"from": "babel-plugin-transform-es2015-parameters@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.11.4.tgz",
-					"version": "6.11.4"
+					"from": "babel-plugin-transform-es2015-parameters@>=6.16.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.17.0.tgz",
+					"version": "6.17.0"
 				},
 				"babel-plugin-transform-es2015-shorthand-properties": {
 					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
@@ -1247,9 +1191,9 @@
 					"version": "6.11.0"
 				},
 				"babel-plugin-transform-regenerator": {
-					"from": "babel-plugin-transform-regenerator@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.11.4.tgz",
-					"version": "6.11.4"
+					"from": "babel-plugin-transform-regenerator@>=6.16.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz",
+					"version": "6.16.1"
 				},
 				"babel-plugin-transform-strict-mode": {
 					"from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0",
@@ -1257,72 +1201,71 @@
 					"version": "6.11.3"
 				},
 				"babel-preset-es2015": {
-					"from": "babel-preset-es2015@>=6.1.18 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-preset-es2015@>=6.0.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.16.0.tgz",
+					"version": "6.16.0"
 				},
-				"babel-preset-metal": {
-					"from": "babel-preset-metal@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-metal/-/babel-preset-metal-3.1.0.tgz",
-					"version": "3.1.0"
+				"babel-preset-metal-resolve-source": {
+					"from": "babel-preset-metal-resolve-source@>=1.0.0 <2.0.0",
+					"version": "1.0.1"
 				},
 				"babel-register": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.14.0.tgz",
-							"version": "4.14.0"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
+							"version": "4.16.4"
 						}
 					},
-					"from": "babel-register@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.11.5.tgz",
-					"version": "6.11.5"
+					"from": "babel-register@>=6.16.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.16.3.tgz",
+					"version": "6.16.3"
 				},
 				"babel-runtime": {
 					"from": "babel-runtime@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.2.tgz",
-					"version": "6.9.2"
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
+					"version": "6.11.6"
 				},
 				"babel-template": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.14.0.tgz",
-							"version": "4.14.0"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
+							"version": "4.16.4"
 						}
 					},
 					"from": "babel-template@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.9.0.tgz",
-					"version": "6.9.0"
+					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
+					"version": "6.16.0"
 				},
 				"babel-traverse": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.14.0.tgz",
-							"version": "4.14.0"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
+							"version": "4.16.4"
 						}
 					},
-					"from": "babel-traverse@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.11.4.tgz",
-					"version": "6.11.4"
+					"from": "babel-traverse@>=6.16.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.16.0.tgz",
+					"version": "6.16.0"
 				},
 				"babel-types": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.14.0.tgz",
-							"version": "4.14.0"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
+							"version": "4.16.4"
 						}
 					},
-					"from": "babel-types@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.11.1.tgz",
-					"version": "6.11.1"
+					"from": "babel-types@>=6.16.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.16.0.tgz",
+					"version": "6.16.0"
 				},
 				"babylon": {
-					"from": "babylon@>=6.7.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.8.4.tgz",
-					"version": "6.8.4"
+					"from": "babylon@>=6.11.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.11.6.tgz",
+					"version": "6.11.6"
 				},
 				"balanced-match": {
 					"from": "balanced-match@>=0.4.1 <0.5.0",
@@ -1394,15 +1337,10 @@
 					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
 					"version": "0.0.1"
 				},
-				"closure-templates-incrementaldom": {
-					"from": "closure-templates-incrementaldom@>=0.0.3 <0.0.4",
-					"resolved": "https://registry.npmjs.org/closure-templates-incrementaldom/-/closure-templates-incrementaldom-0.0.3.tgz",
-					"version": "0.0.3"
-				},
 				"code-point-at": {
 					"from": "code-point-at@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"concat-map": {
 					"from": "concat-map@0.0.1",
@@ -1429,6 +1367,23 @@
 					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 					"version": "1.0.2"
 				},
+				"css": {
+					"dependencies": {
+						"inherits": {
+							"from": "inherits@>=2.0.1 <3.0.0",
+							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+							"version": "2.0.3"
+						},
+						"source-map": {
+							"from": "source-map@>=0.1.38 <0.2.0",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+							"version": "0.1.43"
+						}
+					},
+					"from": "css@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
+					"version": "2.2.1"
+				},
 				"currently-unhandled": {
 					"from": "currently-unhandled@>=0.4.1 <0.5.0",
 					"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -1444,6 +1399,18 @@
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
 					"version": "2.2.0"
 				},
+				"debug-fabulous": {
+					"dependencies": {
+						"object-assign": {
+							"from": "object-assign@4.1.0",
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+							"version": "4.1.0"
+						}
+					},
+					"from": "debug-fabulous@>=0.0.0 <0.1.0",
+					"resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
+					"version": "0.0.4"
+				},
 				"decamelize": {
 					"from": "decamelize@>=1.1.2 <2.0.0",
 					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -1453,6 +1420,11 @@
 					"from": "detect-indent@>=3.0.1 <4.0.0",
 					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
 					"version": "3.0.1"
+				},
+				"detect-newline": {
+					"from": "detect-newline@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+					"version": "2.1.0"
 				},
 				"duplexer": {
 					"from": "duplexer@>=0.1.1 <0.2.0",
@@ -1468,8 +1440,8 @@
 					"dependencies": {
 						"inherits": {
 							"from": "inherits@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-							"version": "2.0.1"
+							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+							"version": "2.0.3"
 						},
 						"isarray": {
 							"from": "isarray@>=1.0.0 <1.1.0",
@@ -1478,8 +1450,8 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
-							"version": "2.1.4"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+							"version": "2.1.5"
 						}
 					},
 					"from": "duplexify@>=3.4.2 <4.0.0",
@@ -1527,6 +1499,13 @@
 					"version": "2.0.1"
 				},
 				"extglob": {
+					"dependencies": {
+						"is-extglob": {
+							"from": "is-extglob@>=1.0.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+							"version": "1.0.0"
+						}
+					},
 					"from": "extglob@>=0.3.1 <0.4.0",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 					"version": "0.3.2"
@@ -1565,8 +1544,8 @@
 				},
 				"for-in": {
 					"from": "for-in@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz",
-					"version": "0.1.5"
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
+					"version": "0.1.6"
 				},
 				"for-own": {
 					"from": "for-own@>=0.1.3 <0.2.0",
@@ -1594,6 +1573,23 @@
 					"version": "3.1.21"
 				},
 				"glob-base": {
+					"dependencies": {
+						"glob-parent": {
+							"from": "glob-parent@>=2.0.0 <3.0.0",
+							"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+							"version": "2.0.0"
+						},
+						"is-extglob": {
+							"from": "is-extglob@>=1.0.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+							"version": "1.0.0"
+						},
+						"is-glob": {
+							"from": "is-glob@>=2.0.0 <3.0.0",
+							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+							"version": "2.0.1"
+						}
+					},
 					"from": "glob-base@>=0.3.0 <0.4.0",
 					"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 					"version": "0.3.0"
@@ -1607,8 +1603,8 @@
 						},
 						"inherits": {
 							"from": "inherits@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-							"version": "2.0.1"
+							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+							"version": "2.0.3"
 						},
 						"lodash": {
 							"from": "lodash@>=1.2.0 <1.3.0",
@@ -1626,9 +1622,9 @@
 					"version": "0.1.0"
 				},
 				"glob-parent": {
-					"from": "glob-parent@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "glob-parent@>=3.0.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.0.tgz",
+					"version": "3.0.0"
 				},
 				"glob-stream": {
 					"dependencies": {
@@ -1639,13 +1635,13 @@
 						},
 						"inherits": {
 							"from": "inherits@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-							"version": "2.0.1"
+							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+							"version": "2.0.3"
 						},
 						"minimatch": {
 							"from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
-							"version": "3.0.2"
+							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+							"version": "3.0.3"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=1.0.33-1 <1.1.0-0",
@@ -1659,8 +1655,8 @@
 						}
 					},
 					"from": "glob-stream@>=5.3.2 <6.0.0",
-					"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.2.tgz",
-					"version": "5.3.2"
+					"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+					"version": "5.3.5"
 				},
 				"glob-watcher": {
 					"from": "glob-watcher@>=2.0.0 <3.0.0",
@@ -1711,8 +1707,8 @@
 					"dependencies": {
 						"minimatch": {
 							"from": "minimatch@>=3.0.0 <4.0.0",
-							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
-							"version": "3.0.2"
+							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+							"version": "3.0.3"
 						}
 					},
 					"from": "gulp-match@>=1.0.2 <2.0.0",
@@ -1723,8 +1719,8 @@
 					"dependencies": {
 						"inherits": {
 							"from": "inherits@>=2.0.1 <2.1.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-							"version": "2.0.1"
+							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+							"version": "2.0.3"
 						},
 						"isarray": {
 							"from": "isarray@>=1.0.0 <1.1.0",
@@ -1733,8 +1729,8 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
-							"version": "2.1.4"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+							"version": "2.1.5"
 						}
 					},
 					"from": "gulp-replace@>=0.5.4 <0.6.0",
@@ -1744,19 +1740,19 @@
 				"gulp-sourcemaps": {
 					"dependencies": {
 						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-							"version": "4.1.4"
+							"from": "graceful-fs@>=4.0.0 <5.0.0",
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+							"version": "4.1.9"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
-							"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz",
-							"version": "1.1.1"
+							"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+							"version": "1.2.0"
 						}
 					},
 					"from": "gulp-sourcemaps@>=1.6.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-					"version": "1.6.0"
+					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.7.3.tgz",
+					"version": "1.7.3"
 				},
 				"gulp-util": {
 					"from": "gulp-util@>=3.0.5 <4.0.0",
@@ -1767,8 +1763,8 @@
 					"dependencies": {
 						"inherits": {
 							"from": "inherits@>=2.0.1 <2.1.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-							"version": "2.0.1"
+							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+							"version": "2.0.3"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=1.0.33-1 <1.1.0-0",
@@ -1824,8 +1820,8 @@
 				},
 				"inflight": {
 					"from": "inflight@>=1.0.4 <2.0.0",
-					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-					"version": "1.0.5"
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"version": "1.0.6"
 				},
 				"inherits": {
 					"from": "inherits@>=1.0.0 <2.0.0",
@@ -1849,8 +1845,8 @@
 				},
 				"is-buffer": {
 					"from": "is-buffer@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
-					"version": "1.1.3"
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
+					"version": "1.1.4"
 				},
 				"is-builtin-module": {
 					"from": "is-builtin-module@>=1.0.0 <2.0.0",
@@ -1873,14 +1869,14 @@
 					"version": "0.1.1"
 				},
 				"is-extglob": {
-					"from": "is-extglob@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"version": "1.0.0"
+					"from": "is-extglob@>=2.1.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.0.tgz",
+					"version": "2.1.0"
 				},
 				"is-finite": {
 					"from": "is-finite@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"is-fullwidth-code-point": {
 					"from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
@@ -1888,9 +1884,9 @@
 					"version": "1.0.0"
 				},
 				"is-glob": {
-					"from": "is-glob@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"version": "2.0.1"
+					"from": "is-glob@>=3.0.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+					"version": "3.1.0"
 				},
 				"is-number": {
 					"from": "is-number@>=2.1.0 <3.0.0",
@@ -1971,15 +1967,20 @@
 				},
 				"kind-of": {
 					"from": "kind-of@>=3.0.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
-					"version": "3.0.3"
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
+					"version": "3.0.4"
+				},
+				"lazy-debug-legacy": {
+					"from": "lazy-debug-legacy@>=0.0.0 <0.1.0",
+					"resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
+					"version": "0.0.1"
 				},
 				"lazystream": {
 					"dependencies": {
 						"inherits": {
 							"from": "inherits@>=2.0.1 <2.1.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-							"version": "2.0.1"
+							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+							"version": "2.0.3"
 						},
 						"isarray": {
 							"from": "isarray@>=1.0.0 <1.1.0",
@@ -1988,8 +1989,8 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.5 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
-							"version": "2.1.4"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+							"version": "2.1.5"
 						}
 					},
 					"from": "lazystream@>=1.0.0 <2.0.0",
@@ -2005,8 +2006,8 @@
 					"dependencies": {
 						"graceful-fs": {
 							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-							"version": "4.1.4"
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+							"version": "4.1.9"
 						}
 					},
 					"from": "load-json-file@>=1.0.0 <2.0.0",
@@ -2070,8 +2071,8 @@
 				},
 				"lodash.isarguments": {
 					"from": "lodash.isarguments@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.9.tgz",
-					"version": "3.0.9"
+					"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+					"version": "3.1.0"
 				},
 				"lodash.isarray": {
 					"from": "lodash.isarray@>=3.0.0 <4.0.0",
@@ -2080,8 +2081,8 @@
 				},
 				"lodash.isequal": {
 					"from": "lodash.isequal@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.3.0.tgz",
-					"version": "4.3.0"
+					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.4.0.tgz",
+					"version": "4.4.0"
 				},
 				"lodash.keys": {
 					"from": "lodash.keys@>=3.0.0 <4.0.0",
@@ -2151,8 +2152,8 @@
 					"dependencies": {
 						"inherits": {
 							"from": "inherits@>=2.0.1 <2.1.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-							"version": "2.0.1"
+							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+							"version": "2.0.3"
 						},
 						"isarray": {
 							"from": "isarray@>=1.0.0 <1.1.0",
@@ -2161,8 +2162,8 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
-							"version": "2.1.4"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+							"version": "2.1.5"
 						}
 					},
 					"from": "merge-stream@>=1.0.0 <2.0.0",
@@ -2176,13 +2177,13 @@
 				},
 				"metal-tools-build-amd": {
 					"from": "metal-tools-build-amd@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-amd/-/metal-tools-build-amd-3.0.0.tgz",
-					"version": "3.0.0"
+					"resolved": "https://registry.npmjs.org/metal-tools-build-amd/-/metal-tools-build-amd-3.0.1.tgz",
+					"version": "3.0.1"
 				},
 				"metal-tools-build-globals": {
 					"from": "metal-tools-build-globals@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-globals/-/metal-tools-build-globals-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/metal-tools-build-globals/-/metal-tools-build-globals-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"metal-tools-build-jquery": {
 					"from": "metal-tools-build-jquery@>=2.0.0 <3.0.0",
@@ -2191,9 +2192,22 @@
 				},
 				"metal-tools-soy": {
 					"from": "metal-tools-soy@>=3.0.0 <4.0.0",
-					"version": "3.0.0"
+					"resolved": "https://registry.npmjs.org/metal-tools-soy/-/metal-tools-soy-3.0.2.tgz",
+					"version": "3.0.2"
 				},
 				"micromatch": {
+					"dependencies": {
+						"is-extglob": {
+							"from": "is-extglob@>=1.0.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+							"version": "1.0.0"
+						},
+						"is-glob": {
+							"from": "is-glob@>=2.0.1 <3.0.0",
+							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+							"version": "2.0.1"
+						}
+					},
 					"from": "micromatch@>=2.3.7 <3.0.0",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 					"version": "2.3.11"
@@ -2252,8 +2266,8 @@
 				},
 				"number-is-nan": {
 					"from": "number-is-nan@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"object-assign": {
 					"from": "object-assign@>=3.0.0 <4.0.0",
@@ -2274,8 +2288,8 @@
 					"dependencies": {
 						"inherits": {
 							"from": "inherits@>=2.0.1 <2.1.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-							"version": "2.0.1"
+							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+							"version": "2.0.3"
 						},
 						"isarray": {
 							"from": "isarray@>=1.0.0 <1.1.0",
@@ -2284,8 +2298,8 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
-							"version": "2.1.4"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+							"version": "2.1.5"
 						}
 					},
 					"from": "ordered-read-streams@>=0.3.0 <0.4.0",
@@ -2299,10 +2313,22 @@
 				},
 				"os-tmpdir": {
 					"from": "os-tmpdir@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"parse-glob": {
+					"dependencies": {
+						"is-extglob": {
+							"from": "is-extglob@>=1.0.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+							"version": "1.0.0"
+						},
+						"is-glob": {
+							"from": "is-glob@>=2.0.0 <3.0.0",
+							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+							"version": "2.0.1"
+						}
+					},
 					"from": "parse-glob@>=3.0.4 <4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 					"version": "3.0.4"
@@ -2319,15 +2345,15 @@
 				},
 				"path-is-absolute": {
 					"from": "path-is-absolute@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"path-type": {
 					"dependencies": {
 						"graceful-fs": {
 							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-							"version": "4.1.4"
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+							"version": "4.1.9"
 						}
 					},
 					"from": "path-type@>=1.0.0 <2.0.0",
@@ -2383,8 +2409,8 @@
 					"dependencies": {
 						"inherits": {
 							"from": "inherits@>=2.0.1 <2.1.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-							"version": "2.0.1"
+							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+							"version": "2.0.3"
 						}
 					},
 					"from": "readable-stream@>=1.1.9 <1.2.0",
@@ -2450,33 +2476,43 @@
 					"dependencies": {
 						"inherits": {
 							"from": "inherits@>=2.0.1 <2.1.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-							"version": "2.0.1"
+							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+							"version": "2.0.3"
 						},
 						"isarray": {
 							"from": "isarray@>=1.0.0 <1.1.0",
 							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 							"version": "1.0.0"
 						},
+						"object-assign": {
+							"from": "object-assign@>=4.0.1 <5.0.0",
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+							"version": "4.1.0"
+						},
 						"readable-stream": {
-							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
-							"version": "2.1.4"
+							"from": "readable-stream@>=2.0.2 <3.0.0",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+							"version": "2.1.5"
 						}
 					},
 					"from": "replacestream@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.0.tgz",
-					"version": "4.0.0"
+					"resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.2.tgz",
+					"version": "4.0.2"
 				},
 				"require-dir": {
 					"from": "require-dir@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/require-dir/-/require-dir-0.3.0.tgz",
-					"version": "0.3.0"
+					"resolved": "https://registry.npmjs.org/require-dir/-/require-dir-0.3.1.tgz",
+					"version": "0.3.1"
 				},
 				"resolve": {
 					"from": "resolve@>=1.1.7 <2.0.0",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
 					"version": "1.1.7"
+				},
+				"resolve-url": {
+					"from": "resolve-url@>=0.2.1 <0.3.0",
+					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+					"version": "0.2.1"
 				},
 				"semver": {
 					"from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
@@ -2495,8 +2531,8 @@
 				},
 				"signal-exit": {
 					"from": "signal-exit@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz",
-					"version": "3.0.0"
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
+					"version": "3.0.1"
 				},
 				"slash": {
 					"from": "slash@>=1.0.0 <2.0.0",
@@ -2508,17 +2544,20 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
 					"version": "0.5.6"
 				},
+				"source-map-resolve": {
+					"from": "source-map-resolve@>=0.3.0 <0.4.0",
+					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
+					"version": "0.3.1"
+				},
 				"source-map-support": {
-					"dependencies": {
-						"source-map": {
-							"from": "source-map@0.1.32",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-							"version": "0.1.32"
-						}
-					},
-					"from": "source-map-support@>=0.2.10 <0.3.0",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-					"version": "0.2.10"
+					"from": "source-map-support@>=0.4.2 <0.5.0",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.3.tgz",
+					"version": "0.4.3"
+				},
+				"source-map-url": {
+					"from": "source-map-url@>=0.3.0 <0.4.0",
+					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+					"version": "0.3.0"
 				},
 				"soyparser": {
 					"from": "soyparser@>=0.2.2 <0.3.0",
@@ -2535,15 +2574,10 @@
 					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"spdx-exceptions": {
-					"from": "spdx-exceptions@>=1.0.4 <2.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.5.tgz",
-					"version": "1.0.5"
-				},
 				"spdx-expression-parse": {
 					"from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-					"version": "1.0.2"
+					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+					"version": "1.0.4"
 				},
 				"spdx-license-ids": {
 					"from": "spdx-license-ids@>=1.0.2 <2.0.0",
@@ -2567,8 +2601,8 @@
 				},
 				"string-width": {
 					"from": "string-width@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"string_decoder": {
 					"from": "string_decoder@>=0.10.0 <0.11.0",
@@ -2619,8 +2653,8 @@
 					"dependencies": {
 						"inherits": {
 							"from": "inherits@>=2.0.1 <2.1.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-							"version": "2.0.1"
+							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+							"version": "2.0.3"
 						},
 						"isarray": {
 							"from": "isarray@>=1.0.0 <1.1.0",
@@ -2672,6 +2706,11 @@
 					"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
 					"version": "2.2.1"
 				},
+				"urix": {
+					"from": "urix@>=0.1.0 <0.2.0",
+					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+					"version": "0.1.0"
+				},
 				"user-home": {
 					"from": "user-home@>=1.1.1 <2.0.0",
 					"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
@@ -2701,13 +2740,13 @@
 					"dependencies": {
 						"graceful-fs": {
 							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-							"version": "4.1.4"
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+							"version": "4.1.9"
 						},
 						"inherits": {
 							"from": "inherits@>=2.0.1 <2.1.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-							"version": "2.0.1"
+							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+							"version": "2.0.3"
 						},
 						"isarray": {
 							"from": "isarray@>=1.0.0 <1.1.0",
@@ -2721,13 +2760,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.4 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
-							"version": "2.1.4"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+							"version": "2.1.5"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
-							"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz",
-							"version": "1.1.1"
+							"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+							"version": "1.2.0"
 						}
 					},
 					"from": "vinyl-fs@>=2.2.1 <3.0.0",
@@ -2771,8 +2810,8 @@
 				}
 			},
 			"from": "metal-cli@>=2.0.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-2.0.0.tgz",
-			"version": "2.0.0"
+			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-2.1.2.tgz",
+			"version": "2.1.2"
 		},
 		"metal-clipboard": {
 			"from": "metal-clipboard@>=1.0.0-rc.1 <2.0.0",
@@ -2781,8 +2820,8 @@
 		},
 		"metal-component": {
 			"from": "metal-component@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/metal-component/-/metal-component-1.0.4.tgz",
-			"version": "1.0.4"
+			"resolved": "https://registry.npmjs.org/metal-component/-/metal-component-1.0.5.tgz",
+			"version": "1.0.5"
 		},
 		"metal-components": {
 			"from": "metal-components@1.0.0-rc.19",
@@ -2801,13 +2840,13 @@
 		},
 		"metal-dom": {
 			"from": "metal-dom@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/metal-dom/-/metal-dom-1.0.4.tgz",
-			"version": "1.0.4"
+			"resolved": "https://registry.npmjs.org/metal-dom/-/metal-dom-1.0.5.tgz",
+			"version": "1.0.5"
 		},
 		"metal-drag-drop": {
 			"from": "metal-drag-drop@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/metal-drag-drop/-/metal-drag-drop-1.0.0.tgz",
-			"version": "1.0.0"
+			"resolved": "https://registry.npmjs.org/metal-drag-drop/-/metal-drag-drop-1.0.1.tgz",
+			"version": "1.0.1"
 		},
 		"metal-dropdown": {
 			"from": "metal-dropdown@>=1.0.0-rc.2 <2.0.0",
@@ -2816,13 +2855,13 @@
 		},
 		"metal-events": {
 			"from": "metal-events@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/metal-events/-/metal-events-1.0.4.tgz",
-			"version": "1.0.4"
+			"resolved": "https://registry.npmjs.org/metal-events/-/metal-events-1.0.5.tgz",
+			"version": "1.0.5"
 		},
 		"metal-incremental-dom": {
-			"from": "metal-incremental-dom@>=1.0.4 <2.0.0",
-			"resolved": "https://registry.npmjs.org/metal-incremental-dom/-/metal-incremental-dom-1.0.4.tgz",
-			"version": "1.0.4"
+			"from": "metal-incremental-dom@>=1.0.5 <2.0.0",
+			"resolved": "https://registry.npmjs.org/metal-incremental-dom/-/metal-incremental-dom-1.0.5.tgz",
+			"version": "1.0.5"
 		},
 		"metal-list": {
 			"from": "metal-list@>=1.0.0-rc.2 <2.0.0",
@@ -2831,8 +2870,8 @@
 		},
 		"metal-modal": {
 			"from": "metal-modal@>=1.0.0-rc.3 <2.0.0",
-			"resolved": "https://registry.npmjs.org/metal-modal/-/metal-modal-1.0.0.tgz",
-			"version": "1.0.0"
+			"resolved": "https://registry.npmjs.org/metal-modal/-/metal-modal-1.0.1.tgz",
+			"version": "1.0.1"
 		},
 		"metal-popover": {
 			"from": "metal-popover@>=1.0.0-rc.3 <2.0.0",
@@ -2846,8 +2885,8 @@
 		},
 		"metal-progressbar": {
 			"from": "metal-progressbar@>=1.0.0-rc.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/metal-progressbar/-/metal-progressbar-1.0.0.tgz",
-			"version": "1.0.0"
+			"resolved": "https://registry.npmjs.org/metal-progressbar/-/metal-progressbar-1.0.1.tgz",
+			"version": "1.0.1"
 		},
 		"metal-promise": {
 			"from": "metal-promise@>=1.0.0 <2.0.0",
@@ -2871,23 +2910,23 @@
 		},
 		"metal-slider": {
 			"from": "metal-slider@>=1.0.0-rc.3 <2.0.0",
-			"resolved": "https://registry.npmjs.org/metal-slider/-/metal-slider-1.0.0.tgz",
-			"version": "1.0.0"
+			"resolved": "https://registry.npmjs.org/metal-slider/-/metal-slider-1.1.1.tgz",
+			"version": "1.1.1"
 		},
 		"metal-soy": {
 			"from": "metal-soy@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/metal-soy/-/metal-soy-1.0.4.tgz",
-			"version": "1.0.4"
+			"resolved": "https://registry.npmjs.org/metal-soy/-/metal-soy-1.0.5.tgz",
+			"version": "1.0.5"
 		},
 		"metal-soy-bundle": {
 			"from": "metal-soy-bundle@>=1.1.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/metal-soy-bundle/-/metal-soy-bundle-1.2.1.tgz",
-			"version": "1.2.1"
+			"resolved": "https://registry.npmjs.org/metal-soy-bundle/-/metal-soy-bundle-1.3.1.tgz",
+			"version": "1.3.1"
 		},
 		"metal-state": {
 			"from": "metal-state@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/metal-state/-/metal-state-1.0.4.tgz",
-			"version": "1.0.4"
+			"resolved": "https://registry.npmjs.org/metal-state/-/metal-state-1.0.5.tgz",
+			"version": "1.0.5"
 		},
 		"metal-switcher": {
 			"from": "metal-switcher@>=1.0.0-rc.2 <2.0.0",
@@ -2942,9 +2981,9 @@
 			"version": "0.1.2"
 		},
 		"natives": {
-			"from": "natives@>=1.0.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/natives/-/natives-1.0.2.tgz",
-			"version": "1.0.2"
+			"from": "natives@>=1.1.0 <2.0.0",
+			"resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
+			"version": "1.1.0"
 		},
 		"node-status-codes": {
 			"from": "node-status-codes@>=1.0.0 <2.0.0",
@@ -2956,11 +2995,6 @@
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
 			"version": "3.0.6"
 		},
-		"normalize-package-data": {
-			"from": "normalize-package-data@>=2.3.4 <3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-			"version": "2.3.5"
-		},
 		"normalize-path": {
 			"from": "normalize-path@>=2.0.1 <3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
@@ -2968,8 +3002,8 @@
 		},
 		"number-is-nan": {
 			"from": "number-is-nan@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-			"version": "1.0.0"
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"version": "1.0.1"
 		},
 		"object-assign": {
 			"from": "object-assign@>=3.0.0 <4.0.0",
@@ -2978,18 +3012,18 @@
 		},
 		"object.omit": {
 			"from": "object.omit@>=2.0.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-			"version": "2.0.0"
+			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+			"version": "2.0.1"
 		},
 		"once": {
 			"from": "once@>=1.3.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-			"version": "1.3.3"
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"version": "1.4.0"
 		},
 		"orchestrator": {
 			"from": "orchestrator@>=0.3.0 <0.4.0",
-			"resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
-			"version": "0.3.7"
+			"resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
+			"version": "0.3.8"
 		},
 		"ordered-read-streams": {
 			"from": "ordered-read-streams@>=0.1.0 <0.2.0",
@@ -2998,18 +3032,18 @@
 		},
 		"os-homedir": {
 			"from": "os-homedir@>=1.0.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-			"version": "1.0.1"
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"version": "1.0.2"
 		},
 		"os-tmpdir": {
 			"from": "os-tmpdir@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-			"version": "1.0.1"
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"version": "1.0.2"
 		},
 		"osenv": {
-			"from": "osenv@>=0.1.3 <0.2.0",
-			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-			"version": "0.1.3"
+			"from": "osenv@>=0.1.0 <0.2.0",
+			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+			"version": "0.1.4"
 		},
 		"package-json": {
 			"dependencies": {
@@ -3039,19 +3073,24 @@
 			"version": "3.0.4"
 		},
 		"parse-json": {
-			"from": "parse-json@>=2.2.0 <3.0.0",
+			"from": "parse-json@>=2.1.0 <3.0.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"version": "2.2.0"
 		},
-		"path-exists": {
-			"from": "path-exists@>=2.0.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-			"version": "2.1.0"
+		"parse-passwd": {
+			"from": "parse-passwd@>=1.0.0 <2.0.0",
+			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+			"version": "1.0.0"
 		},
 		"path-is-absolute": {
 			"from": "path-is-absolute@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-			"version": "1.0.0"
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"version": "1.0.1"
+		},
+		"path-parse": {
+			"from": "path-parse@>=1.0.5 <2.0.0",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+			"version": "1.0.5"
 		},
 		"path-root": {
 			"from": "path-root@>=0.1.1 <0.2.0",
@@ -3062,16 +3101,6 @@
 			"from": "path-root-regex@>=0.1.0 <0.2.0",
 			"resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
 			"version": "0.1.2"
-		},
-		"path-type": {
-			"from": "path-type@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-			"version": "1.1.0"
-		},
-		"pify": {
-			"from": "pify@>=2.0.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"version": "2.3.0"
 		},
 		"pinkie": {
 			"from": "pinkie@>=2.0.0 <3.0.0",
@@ -3095,13 +3124,13 @@
 		},
 		"pretty-hrtime": {
 			"from": "pretty-hrtime@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.2.tgz",
-			"version": "1.0.2"
+			"resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"private": {
 			"from": "private@>=0.1.5 <0.2.0",
-			"resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-			"version": "0.1.6"
+			"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+			"version": "0.1.7"
 		},
 		"process-nextick-args": {
 			"from": "process-nextick-args@>=1.0.6 <1.1.0",
@@ -3113,15 +3142,20 @@
 			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
 			"version": "1.2.4"
 		},
+		"pseudomap": {
+			"from": "pseudomap@>=1.0.1 <2.0.0",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"version": "1.0.2"
+		},
 		"randomatic": {
 			"from": "randomatic@>=1.1.3 <2.0.0",
-			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-			"version": "1.1.5"
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+			"version": "1.1.6"
 		},
 		"rc": {
 			"from": "rc@>=1.1.6 <2.0.0",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-			"version": "1.1.6"
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
+			"version": "1.1.7"
 		},
 		"read-all-stream": {
 			"dependencies": {
@@ -3132,23 +3166,13 @@
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-					"version": "2.1.5"
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz",
+					"version": "2.2.3"
 				}
 			},
 			"from": "read-all-stream@>=3.0.0 <4.0.0",
 			"resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
 			"version": "3.1.0"
-		},
-		"read-pkg": {
-			"from": "read-pkg@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-			"version": "1.1.0"
-		},
-		"read-pkg-up": {
-			"from": "read-pkg-up@>=1.0.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-			"version": "1.0.1"
 		},
 		"readable-stream": {
 			"from": "readable-stream@>=1.1.9 <1.2.0",
@@ -3172,11 +3196,6 @@
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
 			"version": "0.6.2"
 		},
-		"redent": {
-			"from": "redent@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-			"version": "1.0.0"
-		},
 		"regex-cache": {
 			"from": "regex-cache@>=0.4.2 <0.5.0",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
@@ -3184,8 +3203,8 @@
 		},
 		"registry-auth-token": {
 			"from": "registry-auth-token@>=3.0.1 <4.0.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.0.1.tgz",
-			"version": "3.0.1"
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.0.tgz",
+			"version": "3.1.0"
 		},
 		"registry-url": {
 			"from": "registry-url@>=3.0.3 <4.0.0",
@@ -3199,8 +3218,8 @@
 		},
 		"repeat-string": {
 			"from": "repeat-string@>=1.5.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-			"version": "1.5.4"
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"version": "1.6.1"
 		},
 		"repeating": {
 			"from": "repeating@>=2.0.0 <3.0.0",
@@ -3214,8 +3233,8 @@
 		},
 		"resolve": {
 			"from": "resolve@>=1.1.7 <2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-			"version": "1.1.7"
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
+			"version": "1.3.2"
 		},
 		"resolve-dir": {
 			"from": "resolve-dir@>=0.1.0 <0.2.0",
@@ -3224,8 +3243,8 @@
 		},
 		"rimraf": {
 			"from": "rimraf@>=2.2.8 <3.0.0",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-			"version": "2.5.4"
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+			"version": "2.6.1"
 		},
 		"semver": {
 			"from": "semver@>=4.1.0 <5.0.0",
@@ -3254,11 +3273,6 @@
 			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
 			"version": "1.0.1"
 		},
-		"signal-exit": {
-			"from": "signal-exit@>=3.0.0 <4.0.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz",
-			"version": "3.0.0"
-		},
 		"slide": {
 			"from": "slide@>=1.1.5 <2.0.0",
 			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
@@ -3273,21 +3287,6 @@
 			"from": "sparkles@>=1.0.0 <2.0.0",
 			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
 			"version": "1.0.0"
-		},
-		"spdx-correct": {
-			"from": "spdx-correct@>=1.0.0 <1.1.0",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-			"version": "1.0.2"
-		},
-		"spdx-expression-parse": {
-			"from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.3.tgz",
-			"version": "1.0.3"
-		},
-		"spdx-license-ids": {
-			"from": "spdx-license-ids@>=1.0.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-			"version": "1.2.2"
 		},
 		"stream-consume": {
 			"from": "stream-consume@>=0.1.0 <0.2.0",
@@ -3310,19 +3309,14 @@
 			"version": "3.0.1"
 		},
 		"strip-bom": {
-			"from": "strip-bom@>=2.0.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-			"version": "2.0.0"
-		},
-		"strip-indent": {
-			"from": "strip-indent@>=1.0.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-			"version": "1.0.1"
+			"from": "strip-bom@>=1.0.0 <2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+			"version": "1.0.0"
 		},
 		"strip-json-comments": {
-			"from": "strip-json-comments@>=1.0.4 <1.1.0",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-			"version": "1.0.4"
+			"from": "strip-json-comments@>=2.0.1 <2.1.0",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"version": "2.0.1"
 		},
 		"supports-color": {
 			"from": "supports-color@>=2.0.0 <3.0.0",
@@ -3337,14 +3331,14 @@
 					"version": "1.0.0"
 				},
 				"readable-stream": {
-					"from": "readable-stream@>=2.0.0 <2.1.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-					"version": "2.0.6"
+					"from": "readable-stream@>=2.1.5 <3.0.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz",
+					"version": "2.2.3"
 				}
 			},
 			"from": "through2@>=2.0.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-			"version": "2.0.1"
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+			"version": "2.0.3"
 		},
 		"tildify": {
 			"from": "tildify@>=1.0.0 <2.0.0",
@@ -3357,14 +3351,9 @@
 			"version": "1.0.1"
 		},
 		"timed-out": {
-			"from": "timed-out@>=2.0.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
-			"version": "2.0.0"
-		},
-		"trim-newlines": {
-			"from": "trim-newlines@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-			"version": "1.0.0"
+			"from": "timed-out@>=3.0.0 <4.0.0",
+			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
+			"version": "3.1.3"
 		},
 		"unc-path-regex": {
 			"from": "unc-path-regex@>=0.1.0 <0.2.0",
@@ -3387,9 +3376,9 @@
 			"version": "1.0.0"
 		},
 		"unzip-response": {
-			"from": "unzip-response@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.0.tgz",
-			"version": "1.0.0"
+			"from": "unzip-response@>=1.0.2 <2.0.0",
+			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+			"version": "1.0.2"
 		},
 		"upath": {
 			"dependencies": {
@@ -3425,18 +3414,13 @@
 		},
 		"uuid": {
 			"from": "uuid@>=2.0.1 <3.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
-			"version": "2.0.2"
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+			"version": "2.0.3"
 		},
 		"v8flags": {
 			"from": "v8flags@>=2.0.2 <3.0.0",
 			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz",
 			"version": "2.0.11"
-		},
-		"validate-npm-package-license": {
-			"from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-			"version": "3.0.1"
 		},
 		"vinyl": {
 			"from": "vinyl@>=0.5.0 <0.6.0",
@@ -3452,18 +3436,13 @@
 				},
 				"graceful-fs": {
 					"from": "graceful-fs@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.10.tgz",
-					"version": "3.0.10"
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+					"version": "3.0.11"
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=1.0.33-1 <1.1.0-0",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"version": "1.0.34"
-				},
-				"strip-bom": {
-					"from": "strip-bom@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-					"version": "1.0.0"
 				},
 				"through2": {
 					"from": "through2@>=0.6.1 <0.7.0",
@@ -3491,9 +3470,9 @@
 			"version": "0.0.10"
 		},
 		"which": {
-			"from": "which@>=1.2.10 <2.0.0",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz",
-			"version": "1.2.10"
+			"from": "which@>=1.2.12 <2.0.0",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
+			"version": "1.2.12"
 		},
 		"widest-line": {
 			"from": "widest-line@>=1.0.0 <2.0.0",
@@ -3507,8 +3486,8 @@
 		},
 		"write-file-atomic": {
 			"from": "write-file-atomic@>=1.1.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.2.0.tgz",
-			"version": "1.2.0"
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
+			"version": "1.3.1"
 		},
 		"xdg-basedir": {
 			"from": "xdg-basedir@>=2.0.0 <3.0.0",
@@ -3516,7 +3495,7 @@
 			"version": "2.0.0"
 		},
 		"xtend": {
-			"from": "xtend@>=4.0.0 <4.1.0",
+			"from": "xtend@>=4.0.1 <4.1.0",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 			"version": "4.0.1"
 		}

--- a/journal-web/package.json
+++ b/journal-web/package.json
@@ -3,7 +3,7 @@
 		"metal-components": "1.0.0-rc.19"
 	},
 	"devDependencies": {
-		"liferay-module-config-generator": "^1.1.10",
+		"liferay-module-config-generator": "^1.2.1",
 		"metal-cli": "^2.0.0"
 	},
 	"name": "journal-web",

--- a/journal-web/src/main/java/com/liferay/journal/web/internal/messaging/CheckArticleMessageListener.java
+++ b/journal-web/src/main/java/com/liferay/journal/web/internal/messaging/CheckArticleMessageListener.java
@@ -27,7 +27,6 @@ import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
-import com.liferay.portal.kernel.scheduler.TriggerFactoryUtil;
 
 import java.util.Map;
 
@@ -59,9 +58,9 @@ public class CheckArticleMessageListener extends BaseMessageListener {
 
 		String className = clazz.getName();
 
-		Trigger trigger = TriggerFactoryUtil.createTrigger(
-			className, className, journalWebConfiguration.checkInterval(),
-			TimeUnit.MINUTE);
+		Trigger trigger = _triggerFactory.createTrigger(
+			className, className, null, null,
+			journalWebConfiguration.checkInterval(), TimeUnit.MINUTE);
 
 		SchedulerEntry schedulerEntry = new SchedulerEntryImpl(
 			className, trigger);
@@ -99,11 +98,10 @@ public class CheckArticleMessageListener extends BaseMessageListener {
 		_schedulerEngineHelper = schedulerEngineHelper;
 	}
 
-	@Reference(unbind = "-")
-	protected void setTriggerFactory(TriggerFactory triggerFactory) {
-	}
-
 	private JournalArticleLocalService _journalArticleLocalService;
 	private SchedulerEngineHelper _schedulerEngineHelper;
+
+	@Reference
+	private TriggerFactory _triggerFactory;
 
 }

--- a/journal-web/src/main/java/com/liferay/journal/web/internal/messaging/CheckArticleMessageListener.java
+++ b/journal-web/src/main/java/com/liferay/journal/web/internal/messaging/CheckArticleMessageListener.java
@@ -17,12 +17,15 @@ package com.liferay.journal.web.internal.messaging;
 import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.web.configuration.JournalWebConfiguration;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
-import com.liferay.portal.kernel.messaging.BaseSchedulerEntryMessageListener;
+import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
+import com.liferay.portal.kernel.scheduler.SchedulerEntry;
+import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
+import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
 import com.liferay.portal.kernel.scheduler.TriggerFactoryUtil;
 
@@ -44,8 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 	configurationPolicy = ConfigurationPolicy.OPTIONAL, immediate = true,
 	service = CheckArticleMessageListener.class
 )
-public class CheckArticleMessageListener
-	extends BaseSchedulerEntryMessageListener {
+public class CheckArticleMessageListener extends BaseMessageListener {
 
 	@Activate
 	protected void activate(Map<String, Object> properties) {
@@ -53,13 +55,19 @@ public class CheckArticleMessageListener
 			ConfigurableUtil.createConfigurable(
 				JournalWebConfiguration.class, properties);
 
-		schedulerEntryImpl.setTrigger(
-			TriggerFactoryUtil.createTrigger(
-				getEventListenerClass(), getEventListenerClass(),
-				journalWebConfiguration.checkInterval(), TimeUnit.MINUTE));
+		Class<?> clazz = getClass();
+
+		String className = clazz.getName();
+
+		Trigger trigger = TriggerFactoryUtil.createTrigger(
+			className, className, journalWebConfiguration.checkInterval(),
+			TimeUnit.MINUTE);
+
+		SchedulerEntry schedulerEntry = new SchedulerEntryImpl(
+			className, trigger);
 
 		_schedulerEngineHelper.register(
-			this, schedulerEntryImpl, DestinationNames.SCHEDULER_DISPATCH);
+			this, schedulerEntry, DestinationNames.SCHEDULER_DISPATCH);
 	}
 
 	@Deactivate

--- a/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/template/JournalTemplateHandler.java
+++ b/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/template/JournalTemplateHandler.java
@@ -28,6 +28,7 @@ import com.liferay.journal.util.JournalContent;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.template.TemplateHandler;
 import com.liferay.portal.kernel.template.TemplateVariableCodeHandler;
 import com.liferay.portal.kernel.template.TemplateVariableGroup;
@@ -174,6 +175,11 @@ public class JournalTemplateHandler extends BaseDDMTemplateHandler {
 
 	@Reference
 	private Portal _portal;
+
+	@Reference(
+		target = "(&(release.bundle.symbolic.name=com.liferay.journal.service)(release.schema.version=1.1.1))"
+	)
+	private Release _release;
 
 	private final TemplateVariableCodeHandler _templateVariableCodeHandler =
 		new DDMTemplateVariableCodeHandler(

--- a/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -212,9 +212,10 @@ request.setAttribute("edit_article.jsp-changeStructure", changeStructure);
 			</liferay-frontend:info-bar>
 		</c:if>
 
-		<aui:translation-manager
+		<liferay-frontend:translation-manager
 			availableLocales="<%= availableLocales %>"
 			changeableDefaultLanguage="<%= changeableDefaultLanguage %>"
+			componentId='<%= renderResponse.getNamespace() + "translationManager" %>'
 			defaultLanguageId="<%= defaultLanguageId %>"
 			id="translationManager"
 		/>

--- a/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
+++ b/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
@@ -144,9 +144,9 @@ renderResponse.setTitle(title);
 												if (selectedItem) {
 													var folderData = {
 														idString: 'parentFolderId',
-														idValue: selectedItem.folderid,
+														idValue: selectedItem.folderId,
 														nameString: 'parentFolderName',
-														nameValue: selectedItem.foldername
+														nameValue: selectedItem.folderName
 													};
 
 													Liferay.Util.selectFolder(folderData, '<portlet:namespace />');

--- a/journal-web/src/main/resources/META-INF/resources/init.jsp
+++ b/journal-web/src/main/resources/META-INF/resources/init.jsp
@@ -55,6 +55,7 @@ page import="com.liferay.dynamic.data.mapping.service.permission.DDMStructurePer
 page import="com.liferay.dynamic.data.mapping.service.permission.DDMTemplatePermission" %><%@
 page import="com.liferay.dynamic.data.mapping.storage.DDMFormValues" %><%@
 page import="com.liferay.dynamic.data.mapping.util.DDMNavigationHelper" %><%@
+page import="com.liferay.dynamic.data.mapping.util.comparator.StructureModifiedDateComparator" %><%@
 page import="com.liferay.frontend.taglib.servlet.taglib.util.AddMenuKeys" %><%@
 page import="com.liferay.item.selector.ItemSelector" %><%@
 page import="com.liferay.item.selector.ItemSelectorReturnType" %><%@

--- a/journal-web/src/main/resources/META-INF/resources/js/content.js
+++ b/journal-web/src/main/resources/META-INF/resources/js/content.js
@@ -156,7 +156,7 @@ AUI.add(
 
 						if (translationManager) {
 							eventHandles.push(
-								translationManager.after('editingLocaleChange', instance._afterEditingLocaleChange, instance)
+								translationManager.on('editingLocaleChange', instance._afterEditingLocaleChange.bind(instance))
 							);
 						}
 

--- a/journal-web/src/main/resources/META-INF/resources/view_more_menu_items.jsp
+++ b/journal-web/src/main/resources/META-INF/resources/view_more_menu_items.jsp
@@ -17,9 +17,9 @@
 <%@ include file="/init.jsp" %>
 
 <%
-String eventName = ParamUtil.getString(request, "eventName", renderResponse.getNamespace() + "selectAddMenuItem");
-
 String keywords = ParamUtil.getString(request, "keywords");
+
+String eventName = ParamUtil.getString(request, "eventName", renderResponse.getNamespace() + "selectAddMenuItem");
 
 PortletURL portletURL = renderResponse.createRenderURL();
 

--- a/poshi.toggle
+++ b/poshi.toggle
@@ -4,4 +4,9 @@
 		<description>Testing toggles in a subrepository.</description>
 		<owner>Michael Hashimoto</owner>
 	</toggle>
+	<toggle name="LPS-67821">
+		<date>2017-02-22</date>
+		<description>Applying Lexicon to web content localization manager.</description>
+		<owner>Anthony Chu</owner>
+	</toggle>
 </toggles>

--- a/poshi.toggle
+++ b/poshi.toggle
@@ -1,12 +1,12 @@
 <toggles>
-	<toggle name="LRQA-COM_LIFERAY_JOURNAL">
-		<date>2016-08-09</date>
-		<description>Testing toggles in a subrepository.</description>
-		<owner>Michael Hashimoto</owner>
-	</toggle>
 	<toggle name="LPS-67821">
 		<date>2017-02-22</date>
 		<description>Applying Lexicon to web content localization manager.</description>
 		<owner>Anthony Chu</owner>
+	</toggle>
+	<toggle name="LRQA-COM_LIFERAY_JOURNAL">
+		<date>2016-08-09</date>
+		<description>Testing toggles in a subrepository.</description>
+		<owner>Michael Hashimoto</owner>
 	</toggle>
 </toggles>

--- a/test.properties
+++ b/test.properties
@@ -13,4 +13,6 @@
 		subrepository-functional-tomcat80-mysql56-jdk8,\
 		subrepository-integration-mysql56-jdk8
 
-	test.batch.run.property.query[subrepository-functional-tomcat80-mysql56-jdk8]=portal.acceptance == true AND testray.main.component.name ~ "Web Content"
+	test.batch.run.property.query[subrepository-functional-tomcat80-mysql56-jdk8]=\
+		(portal.acceptance == "true") AND \
+		(testray.main.component.name ~ "Web Content")

--- a/test.properties
+++ b/test.properties
@@ -9,8 +9,8 @@
 ## Test Batch
 ##
 
-    test.batch.names=\
-        subrepository-functional-tomcat80-mysql56-jdk8,\
-        subrepository-integration-mysql56-jdk8
+	test.batch.names=\
+		subrepository-functional-tomcat80-mysql56-jdk8,\
+		subrepository-integration-mysql56-jdk8
 
-    test.batch.run.property.query[subrepository-functional-tomcat80-mysql56-jdk8]=portal.acceptance == true AND testray.main.component.name ~ "Web Content"
+	test.batch.run.property.query[subrepository-functional-tomcat80-mysql56-jdk8]=portal.acceptance == true AND testray.main.component.name ~ "Web Content"


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-24514
https://issues.liferay.com/browse/LPS-71050

Please also see the following pull sent in parallel: https://github.com/SamZiemer/liferay-portal/pull/204

Sending another pull that adds API to portal-kernel to allow PortletDataHandlers to disable the "Mirror with overwriting" import strategy option if it's not implemented. This pull leverages this to disable the option, since even if it will be implemented at some point, for now it is not. We are targeting this use case for a customer-specific issue.

Please let me know if there are any problems moving forward with this. Thanks.