### PR TITLE
LPS-71907

### DIFF
--- a/journal-api/src/main/resources/com/liferay/journal/util/packageinfo
+++ b/journal-api/src/main/resources/com/liferay/journal/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -88,7 +88,7 @@ public class JournalContentDisplayContext {
 
 	public static JournalContentDisplayContext create(
 			PortletRequest portletRequest, PortletResponse portletResponse,
-			PortletDisplay portletDisplay)
+			PortletDisplay portletDisplay, long ddmStructureClassNameId)
 		throws PortalException {
 
 		JournalContentDisplayContext journalContentDisplayContext =
@@ -103,7 +103,8 @@ public class JournalContentDisplayContext {
 
 			journalContentDisplayContext = new JournalContentDisplayContext(
 				portletRequest, portletResponse,
-				journalContentPortletInstanceConfiguration);
+				journalContentPortletInstanceConfiguration,
+				ddmStructureClassNameId);
 
 			portletRequest.setAttribute(
 				JournalContentDisplayContext.class.getName(),
@@ -897,13 +898,15 @@ public class JournalContentDisplayContext {
 	private JournalContentDisplayContext(
 			PortletRequest portletRequest, PortletResponse portletResponse,
 			JournalContentPortletInstanceConfiguration
-				journalContentPortletInstanceConfiguration)
+				journalContentPortletInstanceConfiguration,
+			long ddmStructureClassNameId)
 		throws PortalException {
 
 		_portletRequest = portletRequest;
 		_portletResponse = portletResponse;
 		_journalContentPortletInstanceConfiguration =
 			journalContentPortletInstanceConfiguration;
+		_ddmStructureClassNameId = ddmStructureClassNameId;
 
 		if (Validator.isNull(getPortletResource()) && !isShowArticle()) {
 			portletRequest.setAttribute(
@@ -931,9 +934,8 @@ public class JournalContentDisplayContext {
 
 		try {
 			ddmTemplate = DDMTemplateLocalServiceUtil.fetchTemplate(
-				articleDisplay.getGroupId(),
-				PortalUtil.getClassNameId(DDMStructure.class), ddmTemplateKey,
-				true);
+				articleDisplay.getGroupId(), _ddmStructureClassNameId,
+				ddmTemplateKey, true);
 		}
 		catch (PortalException pe) {
 			_log.error(
@@ -968,6 +970,7 @@ public class JournalContentDisplayContext {
 	private String _articleId;
 	private List<ContentMetadataAssetAddonEntry>
 		_contentMetadataAssetAddonEntries;
+	private final long _ddmStructureClassNameId;
 	private DDMTemplate _ddmTemplate;
 	private String _ddmTemplateKey;
 	private List<DDMTemplate> _ddmTemplates;

--- a/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -182,9 +182,9 @@ public class JournalContentDisplayContext {
 					JournalWebKeys.JOURNAL_CONTENT);
 
 			_articleDisplay = journalContent.getDisplay(
-				article.getGroupId(), article.getArticleId(), null, null,
-				themeDisplay.getLanguageId(), 1,
-				new PortletRequestModel(_portletRequest, _portletResponse),
+				article.getGroupId(), article.getArticleId(),
+				article.getVersion(), null, null, themeDisplay.getLanguageId(),
+				1, new PortletRequestModel(_portletRequest, _portletResponse),
 				themeDisplay);
 		}
 		else {

--- a/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/configuration/icon/BaseJournalArticlePortletConfigurationIcon.java
+++ b/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/configuration/icon/BaseJournalArticlePortletConfigurationIcon.java
@@ -33,7 +33,8 @@ public abstract class BaseJournalArticlePortletConfigurationIcon
 	extends BaseJSPPortletConfigurationIcon {
 
 	protected JournalContentDisplayContext getJournalContentDisplayContext(
-		PortletRequest portletRequest, PortletResponse portletResponse) {
+		PortletRequest portletRequest, PortletResponse portletResponse,
+		long ddmStructureClassNameId) {
 
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
@@ -42,7 +43,8 @@ public abstract class BaseJournalArticlePortletConfigurationIcon
 
 		try {
 			return JournalContentDisplayContext.create(
-				portletRequest, portletResponse, portletDisplay);
+				portletRequest, portletResponse, portletDisplay,
+				ddmStructureClassNameId);
 		}
 		catch (PortalException pe) {
 			_log.error("Unable to create display context", pe);

--- a/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/configuration/icon/EditJournalArticlePortletConfigurationIcon.java
+++ b/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/configuration/icon/EditJournalArticlePortletConfigurationIcon.java
@@ -14,6 +14,7 @@
 
 package com.liferay.journal.content.web.internal.portlet.configuration.icon;
 
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.journal.content.web.constants.JournalContentPortletKeys;
 import com.liferay.journal.content.web.internal.display.context.JournalContentDisplayContext;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -21,6 +22,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
@@ -79,7 +81,8 @@ public class EditJournalArticlePortletConfigurationIcon
 		}
 
 		JournalContentDisplayContext journalContentDisplayContext =
-			getJournalContentDisplayContext(portletRequest, null);
+			getJournalContentDisplayContext(
+				portletRequest, null, _ddmStructureClassNameId);
 
 		if (journalContentDisplayContext.isShowEditArticleIcon()) {
 			return true;
@@ -97,8 +100,15 @@ public class EditJournalArticlePortletConfigurationIcon
 		super.setServletContext(servletContext);
 	}
 
+	@Reference(unbind = "-")
+	protected void setPortal(Portal portal) {
+		_ddmStructureClassNameId = portal.getClassNameId(DDMStructure.class);
+	}
+
 	private static final boolean _STAGING_LIVE_GROUP_LOCKING_ENABLED =
 		GetterUtil.getBoolean(
 			PropsUtil.get(PropsKeys.STAGING_LIVE_GROUP_LOCKING_ENABLED));
+
+	private long _ddmStructureClassNameId;
 
 }

--- a/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/configuration/icon/EditTemplatePortletConfigurationIcon.java
+++ b/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/configuration/icon/EditTemplatePortletConfigurationIcon.java
@@ -14,9 +14,11 @@
 
 package com.liferay.journal.content.web.internal.portlet.configuration.icon;
 
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.journal.content.web.constants.JournalContentPortletKeys;
 import com.liferay.journal.content.web.internal.display.context.JournalContentDisplayContext;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
+import com.liferay.portal.kernel.util.Portal;
 
 import javax.portlet.PortletRequest;
 
@@ -52,7 +54,8 @@ public class EditTemplatePortletConfigurationIcon
 	@Override
 	public boolean isShow(PortletRequest portletRequest) {
 		JournalContentDisplayContext journalContentDisplayContext =
-			getJournalContentDisplayContext(portletRequest, null);
+			getJournalContentDisplayContext(
+				portletRequest, null, _ddmStructureClassNameId);
 
 		if (journalContentDisplayContext.isShowEditTemplateIcon()) {
 			return true;
@@ -79,5 +82,12 @@ public class EditTemplatePortletConfigurationIcon
 	public void setServletContext(ServletContext servletContext) {
 		super.setServletContext(servletContext);
 	}
+
+	@Reference(unbind = "-")
+	protected void setPortal(Portal portal) {
+		_ddmStructureClassNameId = portal.getClassNameId(DDMStructure.class);
+	}
+
+	private long _ddmStructureClassNameId;
 
 }

--- a/journal-content-web/src/main/resources/META-INF/resources/init.jsp
+++ b/journal-content-web/src/main/resources/META-INF/resources/init.jsp
@@ -72,9 +72,13 @@ page import="javax.portlet.WindowState" %>
 <portlet:defineObjects />
 
 <%
-JournalContentDisplayContext journalContentDisplayContext = JournalContentDisplayContext.create(liferayPortletRequest, liferayPortletResponse, portletDisplay);
+JournalContentDisplayContext journalContentDisplayContext = JournalContentDisplayContext.create(liferayPortletRequest, liferayPortletResponse, portletDisplay, _ddmStructureClassNameId);
 
 Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZone);
+%>
+
+<%!
+private long _ddmStructureClassNameId = PortalUtil.getClassNameId(DDMStructure.class);
 %>
 
 <%@ include file="/init-ext.jsp" %>

--- a/journal-service/build.gradle
+++ b/journal-service/build.gradle
@@ -1,7 +1,7 @@
+apply plugin: "com.liferay.lang.merger"
+
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
-
-apply plugin: "com.liferay.lang.merger"
 
 buildService {
 	apiDir = "../journal-api/src/main/java"

--- a/journal-service/build.gradle
+++ b/journal-service/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.subscription.api", version: "1.0.0-20170308.171906-1"
 	provided group: "com.liferay", name: "com.liferay.xstream.configurator.api", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.24.0-20170327.224758-1"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.util.java", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "2.0.0"
 	provided group: "commons-lang", name: "commons-lang", version: "2.1"

--- a/journal-service/src/main/java/com/liferay/journal/exportimport/data/handler/JournalPortletDataHandler.java
+++ b/journal-service/src/main/java/com/liferay/journal/exportimport/data/handler/JournalPortletDataHandler.java
@@ -129,6 +129,11 @@ public class JournalPortletDataHandler extends BasePortletDataHandler {
 		return true;
 	}
 
+	@Override
+	public boolean isSupportsDataStrategyMirrorWithOverwriting() {
+		return false;
+	}
+
 	@Activate
 	protected void activate() {
 		setDataLocalized(true);

--- a/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/UpgradeImageTypeContent.java
+++ b/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/UpgradeImageTypeContent.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.Node;
@@ -75,6 +76,10 @@ public class UpgradeImageTypeContent extends UpgradeProcess {
 
 			for (Element dynamicContentEl : dynamicContentEls) {
 				String id = dynamicContentEl.attributeValue("id");
+
+				if (Validator.isNull(id)) {
+					continue;
+				}
 
 				long folderId = getFolderId(userId, groupId, resourcePrimKey);
 
@@ -144,6 +149,10 @@ public class UpgradeImageTypeContent extends UpgradeProcess {
 					}
 
 					Image image = _imageLocalService.getImage(articleImageId);
+
+					if (image == null) {
+						continue;
+					}
 
 					PortletFileRepositoryUtil.addPortletFileEntry(
 						groupId, userId, JournalArticle.class.getName(),

--- a/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
+++ b/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
@@ -60,8 +60,10 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.DocumentException;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
+import com.liferay.portal.util.PropsValues;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -345,6 +347,15 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 	}
 
 	@Override
+	public Date getDisplayDate() {
+		if (!PropsValues.SCHEDULER_ENABLED) {
+			return null;
+		}
+
+		return super.getDisplayDate();
+	}
+
+	@Override
 	public Document getDocument() {
 		if (_document == null) {
 			try {
@@ -358,6 +369,15 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 		}
 
 		return _document;
+	}
+
+	@Override
+	public Date getExpirationDate() {
+		if (!PropsValues.SCHEDULER_ENABLED) {
+			return null;
+		}
+
+		return super.getExpirationDate();
 	}
 
 	@Override
@@ -465,6 +485,15 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 	@Deprecated
 	public String getLegacyTitle() {
 		return _title;
+	}
+
+	@Override
+	public Date getReviewDate() {
+		if (!PropsValues.SCHEDULER_ENABLED) {
+			return null;
+		}
+
+		return super.getReviewDate();
 	}
 
 	@Override

--- a/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -44,7 +44,6 @@ import com.liferay.journal.configuration.JournalGroupServiceConfiguration;
 import com.liferay.journal.configuration.JournalServiceConfiguration;
 import com.liferay.journal.constants.JournalConstants;
 import com.liferay.journal.exception.ArticleContentException;
-import com.liferay.journal.exception.ArticleDisplayDateException;
 import com.liferay.journal.exception.ArticleExpirationDateException;
 import com.liferay.journal.exception.ArticleIdException;
 import com.liferay.journal.exception.ArticleReviewDateException;
@@ -332,8 +331,7 @@ public class JournalArticleLocalServiceImpl
 		if (classNameId == JournalArticleConstants.CLASSNAME_ID_DEFAULT) {
 			displayDate = PortalUtil.getDate(
 				displayDateMonth, displayDateDay, displayDateYear,
-				displayDateHour, displayDateMinute, user.getTimeZone(),
-				ArticleDisplayDateException.class);
+				displayDateHour, displayDateMinute, user.getTimeZone(), null);
 
 			if (!neverExpire) {
 				expirationDate = PortalUtil.getDate(
@@ -5359,8 +5357,7 @@ public class JournalArticleLocalServiceImpl
 
 			displayDate = PortalUtil.getDate(
 				displayDateMonth, displayDateDay, displayDateYear,
-				displayDateHour, displayDateMinute, user.getTimeZone(),
-				ArticleDisplayDateException.class);
+				displayDateHour, displayDateMinute, user.getTimeZone(), null);
 
 			if (!neverExpire) {
 				expirationDate = PortalUtil.getDate(

--- a/journal-service/src/main/java/com/liferay/journal/service/permission/JournalArticlePermission.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/permission/JournalArticlePermission.java
@@ -274,59 +274,63 @@ public class JournalArticlePermission implements BaseModelPermissionChecker {
 			}
 		}
 
-		JournalServiceConfiguration journalServiceConfiguration = null;
+		if (actionId.equals(ActionKeys.VIEW)) {
+			JournalServiceConfiguration journalServiceConfiguration = null;
 
-		try {
-			journalServiceConfiguration =
-				_configurationProvider.getCompanyConfiguration(
-					JournalServiceConfiguration.class,
-					permissionChecker.getCompanyId());
-		}
-		catch (ConfigurationException ce) {
-			_log.error(
-				"Unable to get journal service configuration for company " +
-					permissionChecker.getCompanyId(),
-				ce);
-
-			return false;
-		}
-
-		if (actionId.equals(ActionKeys.VIEW) &&
-			!journalServiceConfiguration.articleViewPermissionsCheckEnabled()) {
-
-			return true;
-		}
-
-		if (actionId.equals(ActionKeys.VIEW) &&
-			PropsValues.PERMISSIONS_VIEW_DYNAMIC_INHERITANCE) {
-
-			long folderId = article.getFolderId();
-
-			if (folderId == JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
-				if (!JournalPermission.contains(
-						permissionChecker, article.getGroupId(), actionId)) {
-
-					return false;
-				}
+			try {
+				journalServiceConfiguration =
+					_configurationProvider.getCompanyConfiguration(
+						JournalServiceConfiguration.class,
+						permissionChecker.getCompanyId());
 			}
-			else {
-				JournalFolder folder = _journalFolderLocalService.fetchFolder(
-					folderId);
+			catch (ConfigurationException ce) {
+				_log.error(
+					"Unable to get journal service configuration for company " +
+						permissionChecker.getCompanyId(),
+					ce);
 
-				if (folder != null) {
-					if (!JournalFolderPermission.contains(
-							permissionChecker, folder, ActionKeys.ACCESS) &&
-						!JournalFolderPermission.contains(
-							permissionChecker, folder, ActionKeys.VIEW)) {
+				return false;
+			}
+
+			if (!journalServiceConfiguration.
+					articleViewPermissionsCheckEnabled()) {
+
+				return true;
+			}
+
+			if (PropsValues.PERMISSIONS_VIEW_DYNAMIC_INHERITANCE) {
+				long folderId = article.getFolderId();
+
+				if (folderId ==
+						JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+
+					if (!JournalPermission.contains(
+							permissionChecker, article.getGroupId(),
+							actionId)) {
 
 						return false;
 					}
 				}
 				else {
-					if (!article.isInTrash()) {
-						_log.error("Unable to get journal folder " + folderId);
+					JournalFolder folder =
+						_journalFolderLocalService.fetchFolder(folderId);
 
-						return false;
+					if (folder != null) {
+						if (!JournalFolderPermission.contains(
+								permissionChecker, folder, ActionKeys.ACCESS) &&
+							!JournalFolderPermission.contains(
+								permissionChecker, folder, ActionKeys.VIEW)) {
+
+							return false;
+						}
+					}
+					else {
+						if (!article.isInTrash()) {
+							_log.error(
+								"Unable to get journal folder " + folderId);
+
+							return false;
+						}
 					}
 				}
 			}

--- a/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticleLocalizationPersistenceImpl.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticleLocalizationPersistenceImpl.java
@@ -1363,7 +1363,7 @@ public class JournalArticleLocalizationPersistenceImpl
 		query.append(_SQL_SELECT_JOURNALARTICLELOCALIZATION_WHERE_PKS_IN);
 
 		for (Serializable primaryKey : uncachedPrimaryKeys) {
-			query.append(String.valueOf(primaryKey));
+			query.append((long)primaryKey);
 
 			query.append(StringPool.COMMA);
 		}

--- a/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticlePersistenceImpl.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticlePersistenceImpl.java
@@ -32997,7 +32997,7 @@ public class JournalArticlePersistenceImpl extends BasePersistenceImpl<JournalAr
 		query.append(_SQL_SELECT_JOURNALARTICLE_WHERE_PKS_IN);
 
 		for (Serializable primaryKey : uncachedPrimaryKeys) {
-			query.append(String.valueOf(primaryKey));
+			query.append((long)primaryKey);
 
 			query.append(StringPool.COMMA);
 		}

--- a/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticleResourcePersistenceImpl.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticleResourcePersistenceImpl.java
@@ -2850,7 +2850,7 @@ public class JournalArticleResourcePersistenceImpl extends BasePersistenceImpl<J
 		query.append(_SQL_SELECT_JOURNALARTICLERESOURCE_WHERE_PKS_IN);
 
 		for (Serializable primaryKey : uncachedPrimaryKeys) {
-			query.append(String.valueOf(primaryKey));
+			query.append((long)primaryKey);
 
 			query.append(StringPool.COMMA);
 		}

--- a/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalContentSearchPersistenceImpl.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalContentSearchPersistenceImpl.java
@@ -5319,7 +5319,7 @@ public class JournalContentSearchPersistenceImpl extends BasePersistenceImpl<Jou
 		query.append(_SQL_SELECT_JOURNALCONTENTSEARCH_WHERE_PKS_IN);
 
 		for (Serializable primaryKey : uncachedPrimaryKeys) {
-			query.append(String.valueOf(primaryKey));
+			query.append((long)primaryKey);
 
 			query.append(StringPool.COMMA);
 		}

--- a/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalFeedPersistenceImpl.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalFeedPersistenceImpl.java
@@ -3199,7 +3199,7 @@ public class JournalFeedPersistenceImpl extends BasePersistenceImpl<JournalFeed>
 		query.append(_SQL_SELECT_JOURNALFEED_WHERE_PKS_IN);
 
 		for (Serializable primaryKey : uncachedPrimaryKeys) {
-			query.append(String.valueOf(primaryKey));
+			query.append((long)primaryKey);
 
 			query.append(StringPool.COMMA);
 		}

--- a/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalFolderPersistenceImpl.java
+++ b/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalFolderPersistenceImpl.java
@@ -7999,7 +7999,7 @@ public class JournalFolderPersistenceImpl extends BasePersistenceImpl<JournalFol
 		query.append(_SQL_SELECT_JOURNALFOLDER_WHERE_PKS_IN);
 
 		for (Serializable primaryKey : uncachedPrimaryKeys) {
-			query.append(String.valueOf(primaryKey));
+			query.append((long)primaryKey);
 
 			query.append(StringPool.COMMA);
 		}

--- a/journal-web/src/main/java/com/liferay/journal/web/asset/JournalArticleAssetRenderer.java
+++ b/journal-web/src/main/java/com/liferay/journal/web/asset/JournalArticleAssetRenderer.java
@@ -569,7 +569,7 @@ public class JournalArticleAssetRenderer
 	}
 
 	/**
-	 * @deprecated As of 2.0.0, with no direct replacement
+	 * @deprecated As of 1.7.0, with no direct replacement
 	 */
 	@Deprecated
 	protected void setJournalServiceConfiguration() {

--- a/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -674,6 +674,12 @@ public class JournalDisplayContext {
 				"showEditActions", String.valueOf(isShowEditActions()));
 		}
 
+		String tabs1 = getTabs1();
+
+		if (Validator.isNotNull(tabs1)) {
+			portletURL.setParameter("tabs1", tabs1);
+		}
+
 		return portletURL;
 	}
 
@@ -993,6 +999,16 @@ public class JournalDisplayContext {
 		_status = ParamUtil.getInteger(_request, "status", defaultStatus);
 
 		return _status;
+	}
+
+	public String getTabs1() {
+		if (_tabs1 != null) {
+			return _tabs1;
+		}
+
+		_tabs1 = ParamUtil.getString(_request, "tabs1");
+
+		return _tabs1;
 	}
 
 	public int getTotal() throws PortalException {
@@ -1349,5 +1365,6 @@ public class JournalDisplayContext {
 	private Integer _restrictionType;
 	private Boolean _showEditActions;
 	private Integer _status;
+	private String _tabs1;
 
 }

--- a/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -77,6 +77,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -93,13 +94,11 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 import javax.portlet.PortletException;
 import javax.portlet.PortletPreferences;
@@ -178,18 +177,20 @@ public class JournalDisplayContext {
 		return _articleDisplay;
 	}
 
-	public Set getAvailableArticleLocales() throws PortalException {
-		Set<Locale> availableLocalesSet = new HashSet<>();
-
+	public List<Locale> getAvailableArticleLocales() throws PortalException {
 		JournalArticle article = getArticle();
 
-		if (article != null) {
-			Map<Locale, String> titleMap = article.getTitleMap();
-
-			availableLocalesSet.addAll(titleMap.keySet());
+		if (article == null) {
+			return Collections.emptyList();
 		}
 
-		return availableLocalesSet;
+		List<Locale> availableLocales = new ArrayList<>();
+
+		for (String languageId : article.getAvailableLanguageIds()) {
+			availableLocales.add(LocaleUtil.fromLanguageId(languageId));
+		}
+
+		return availableLocales;
 	}
 
 	public String[] getCharactersBlacklist() throws PortalException {

--- a/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -93,11 +93,13 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import javax.portlet.PortletException;
 import javax.portlet.PortletPreferences;
@@ -174,6 +176,20 @@ public class JournalDisplayContext {
 			themeDisplay);
 
 		return _articleDisplay;
+	}
+
+	public Set getAvailableArticleLocales() throws PortalException {
+		Set<Locale> availableLocalesSet = new HashSet<>();
+
+		JournalArticle article = getArticle();
+
+		if (article != null) {
+			Map<Locale, String> titleMap = article.getTitleMap();
+
+			availableLocalesSet.addAll(titleMap.keySet());
+		}
+
+		return availableLocalesSet;
 	}
 
 	public String[] getCharactersBlacklist() throws PortalException {

--- a/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/JournalPortlet.java
+++ b/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/JournalPortlet.java
@@ -739,7 +739,7 @@ public class JournalPortlet extends MVCPortlet {
 		int expirationDateAmPm = ParamUtil.getInteger(
 			uploadPortletRequest, "expirationDateAmPm");
 		boolean neverExpire = ParamUtil.getBoolean(
-			uploadPortletRequest, "neverExpire");
+			uploadPortletRequest, "neverExpire", true);
 
 		if (expirationDateAmPm == Calendar.PM) {
 			expirationDateHour += 12;
@@ -758,7 +758,7 @@ public class JournalPortlet extends MVCPortlet {
 		int reviewDateAmPm = ParamUtil.getInteger(
 			uploadPortletRequest, "reviewDateAmPm");
 		boolean neverReview = ParamUtil.getBoolean(
-			uploadPortletRequest, "neverReview");
+			uploadPortletRequest, "neverReview", true);
 
 		if (reviewDateAmPm == Calendar.PM) {
 			reviewDateHour += 12;

--- a/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/JournalPortlet.java
+++ b/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/JournalPortlet.java
@@ -109,6 +109,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.util.PropsValues;
 import com.liferay.trash.kernel.service.TrashEntryService;
 import com.liferay.trash.kernel.util.TrashUtil;
 
@@ -739,7 +740,11 @@ public class JournalPortlet extends MVCPortlet {
 		int expirationDateAmPm = ParamUtil.getInteger(
 			uploadPortletRequest, "expirationDateAmPm");
 		boolean neverExpire = ParamUtil.getBoolean(
-			uploadPortletRequest, "neverExpire", true);
+			uploadPortletRequest, "neverExpire");
+
+		if (!PropsValues.SCHEDULER_ENABLED) {
+			neverExpire = true;
+		}
 
 		if (expirationDateAmPm == Calendar.PM) {
 			expirationDateHour += 12;
@@ -758,7 +763,11 @@ public class JournalPortlet extends MVCPortlet {
 		int reviewDateAmPm = ParamUtil.getInteger(
 			uploadPortletRequest, "reviewDateAmPm");
 		boolean neverReview = ParamUtil.getBoolean(
-			uploadPortletRequest, "neverReview", true);
+			uploadPortletRequest, "neverReview");
+
+		if (!PropsValues.SCHEDULER_ENABLED) {
+			neverReview = true;
+		}
 
 		if (reviewDateAmPm == Calendar.PM) {
 			reviewDateHour += 12;

--- a/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/CopyArticleMVCActionCommand.java
+++ b/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/CopyArticleMVCActionCommand.java
@@ -18,7 +18,6 @@ import com.liferay.journal.constants.JournalPortletKeys;
 import com.liferay.journal.exception.ArticleIdException;
 import com.liferay.journal.exception.DuplicateArticleIdException;
 import com.liferay.journal.exception.NoSuchArticleException;
-import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleService;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
@@ -59,7 +58,7 @@ public class CopyArticleMVCActionCommand extends BaseMVCActionCommand {
 			actionRequest, "autoArticleId");
 		double version = ParamUtil.getDouble(actionRequest, "version");
 
-		JournalArticle newArticle = _journalArticleService.copyArticle(
+		_journalArticleService.copyArticle(
 			groupId, oldArticleId, newArticleId, autoArticleId, version);
 	}
 

--- a/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/CopyArticleMVCActionCommand.java
+++ b/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/CopyArticleMVCActionCommand.java
@@ -20,25 +20,17 @@ import com.liferay.journal.exception.DuplicateArticleIdException;
 import com.liferay.journal.exception.NoSuchArticleException;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleService;
-import com.liferay.portal.kernel.portlet.PortletProvider;
-import com.liferay.portal.kernel.portlet.PortletProviderUtil;
-import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.PortalUtil;
-import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.kernel.util.WebKeys;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
 import javax.portlet.PortletContext;
-import javax.portlet.PortletRequest;
 import javax.portlet.PortletRequestDispatcher;
 import javax.portlet.PortletSession;
-import javax.portlet.PortletURL;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -69,32 +61,6 @@ public class CopyArticleMVCActionCommand extends BaseMVCActionCommand {
 
 		JournalArticle newArticle = _journalArticleService.copyArticle(
 			groupId, oldArticleId, newArticleId, autoArticleId, version);
-
-		String redirect = ParamUtil.getString(actionRequest, WebKeys.REDIRECT);
-
-		if (!Validator.isBlank(redirect)) {
-			redirect = PortalUtil.escapeRedirect(redirect);
-		}
-		else {
-			PortletURL listURL = PortletURLFactoryUtil.create(
-				actionRequest, JournalPortletKeys.JOURNAL,
-				PortletRequest.RENDER_PHASE);
-
-			redirect = listURL.toString();
-		}
-
-		PortletURL redirectURL = PortletProviderUtil.getPortletURL(
-			actionRequest, JournalArticle.class.getName(),
-			PortletProvider.Action.EDIT);
-
-		redirectURL.setParameter("mvcPath", "/edit_article.jsp");
-		redirectURL.setParameter("redirect", redirect);
-		redirectURL.setParameter("groupId", String.valueOf(groupId));
-		redirectURL.setParameter("articleId", newArticle.getArticleId());
-
-		actionRequest.setAttribute(WebKeys.REDIRECT, redirectURL.toString());
-
-		hideDefaultSuccessMessage(actionRequest);
 	}
 
 	@Override

--- a/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UploadImageMVCActionCommand.java
+++ b/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UploadImageMVCActionCommand.java
@@ -14,6 +14,7 @@
 
 package com.liferay.journal.web.internal.portlet.action;
 
+import com.liferay.document.library.kernel.util.DLValidator;
 import com.liferay.journal.configuration.JournalFileUploadsConfiguration;
 import com.liferay.journal.constants.JournalPortletKeys;
 import com.liferay.journal.web.internal.upload.ImageJournalUploadHandler;
@@ -30,6 +31,7 @@ import javax.portlet.ActionResponse;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Eduardo Garcia
@@ -49,6 +51,7 @@ public class UploadImageMVCActionCommand extends BaseMVCActionCommand {
 	@Modified
 	protected void activate(Map<String, Object> properties) {
 		_uploadHandler = new ImageJournalUploadHandler(
+			_dlValidator,
 			ConfigurableUtil.createConfigurable(
 				JournalFileUploadsConfiguration.class, properties));
 	}
@@ -60,6 +63,9 @@ public class UploadImageMVCActionCommand extends BaseMVCActionCommand {
 
 		_uploadHandler.upload(actionRequest, actionResponse);
 	}
+
+	@Reference
+	private DLValidator _dlValidator;
 
 	private volatile UploadHandler _uploadHandler;
 

--- a/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/ui/JournalScheduleFormNavigatorEntry.java
+++ b/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/ui/JournalScheduleFormNavigatorEntry.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.servlet.taglib.ui.FormNavigatorEntry;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.util.PropsValues;
 
 import javax.servlet.ServletContext;
 
@@ -45,6 +46,10 @@ public class JournalScheduleFormNavigatorEntry
 
 	@Override
 	public boolean isVisible(User user, JournalArticle article) {
+		if (!PropsValues.SCHEDULER_ENABLED) {
+			return false;
+		}
+
 		ServiceContext serviceContext =
 			ServiceContextThreadLocal.getServiceContext();
 

--- a/journal-web/src/main/java/com/liferay/journal/web/internal/upload/ImageJournalUploadHandler.java
+++ b/journal-web/src/main/java/com/liferay/journal/web/internal/upload/ImageJournalUploadHandler.java
@@ -14,7 +14,7 @@
 
 package com.liferay.journal.web.internal.upload;
 
-import com.liferay.document.library.kernel.exception.FileSizeException;
+import com.liferay.document.library.kernel.util.DLValidator;
 import com.liferay.journal.configuration.JournalFileUploadsConfiguration;
 import com.liferay.journal.service.permission.JournalPermission;
 import com.liferay.portal.kernel.exception.ImageTypeException;
@@ -32,10 +32,8 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.servlet.ServletResponseConstants;
 import com.liferay.portal.kernel.upload.BaseUploadHandler;
 import com.liferay.portal.kernel.util.FileUtil;
-import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
-import com.liferay.portal.util.PrefsPropsUtil;
 
 import java.io.InputStream;
 
@@ -48,8 +46,10 @@ import javax.portlet.PortletResponse;
 public class ImageJournalUploadHandler extends BaseUploadHandler {
 
 	public ImageJournalUploadHandler(
+		DLValidator dlValidator,
 		JournalFileUploadsConfiguration journalFileUploadsConfiguration) {
 
+		_dlValidator = dlValidator;
 		_journalFileUploadsConfiguration = journalFileUploadsConfiguration;
 	}
 
@@ -57,12 +57,7 @@ public class ImageJournalUploadHandler extends BaseUploadHandler {
 	public void validateFile(String fileName, String contentType, long size)
 		throws PortalException {
 
-		long maxSize = PrefsPropsUtil.getLong(PropsKeys.DL_FILE_MAX_SIZE);
-
-		if ((maxSize > 0) && (size > maxSize)) {
-			throw new FileSizeException(
-				size + " exceeds its maximum permitted size of " + maxSize);
-		}
+		_dlValidator.validateFileSize(fileName, size);
 
 		String extension = FileUtil.getExtension(fileName);
 
@@ -166,6 +161,7 @@ public class ImageJournalUploadHandler extends BaseUploadHandler {
 	private static final Log _log = LogFactoryUtil.getLog(
 		ImageJournalUploadHandler.class);
 
+	private final DLValidator _dlValidator;
 	private final JournalFileUploadsConfiguration
 		_journalFileUploadsConfiguration;
 

--- a/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -176,13 +176,16 @@ request.setAttribute("edit_article.jsp-changeStructure", changeStructure);
 	<%
 	DDMFormValues ddmFormValues = journalDisplayContext.getDDMFormValues(ddmStructure);
 
-	Locale[] availableLocales = new Locale[] {LocaleUtil.fromLanguageId(defaultLanguageId)};
+	Set<Locale> availableLocalesSet = new HashSet<>();
+
+	availableLocalesSet.add(LocaleUtil.fromLanguageId(defaultLanguageId));
+	availableLocalesSet.addAll(journalDisplayContext.getAvailableArticleLocales());
 
 	if (ddmFormValues != null) {
-		Set<Locale> availableLocalesSet = ddmFormValues.getAvailableLocales();
-
-		availableLocales = availableLocalesSet.toArray(new Locale[availableLocalesSet.size()]);
+		availableLocalesSet.addAll(ddmFormValues.getAvailableLocales());
 	}
+
+	Locale[] availableLocales = availableLocalesSet.toArray(new Locale[availableLocalesSet.size()]);
 	%>
 
 	<div class="lfr-form-content">

--- a/journal-web/src/main/resources/META-INF/resources/init.jsp
+++ b/journal-web/src/main/resources/META-INF/resources/init.jsp
@@ -180,6 +180,7 @@ page import="com.liferay.trash.kernel.util.TrashUtil" %>
 <%@ page import="java.util.ArrayList" %><%@
 page import="java.util.Date" %><%@
 page import="java.util.HashMap" %><%@
+page import="java.util.HashSet" %><%@
 page import="java.util.List" %><%@
 page import="java.util.Locale" %><%@
 page import="java.util.Map" %><%@

--- a/journal-web/src/main/resources/META-INF/resources/view.jsp
+++ b/journal-web/src/main/resources/META-INF/resources/view.jsp
@@ -132,32 +132,26 @@ data.put("qa-id", "navigation");
 								portletURL="<%= portletURL %>"
 								tabsValues="<%= StringUtil.merge(tabsValues) %>"
 								type="tabs nav-tabs-default"
-							>
-								<c:if test="<%= journalDisplayContext.hasResults() %>">
-									<liferay-ui:section>
-										<liferay-util:include page="/view_entries.jsp" servletContext="<%= application %>">
-											<liferay-util:param name="searchContainerId" value="articles" />
-										</liferay-util:include>
-									</liferay-ui:section>
-								</c:if>
+							/>
 
-								<c:if test="<%= journalDisplayContext.hasVersionsResults() %>">
-									<liferay-ui:section>
-										<liferay-util:include page="/view_versions.jsp" servletContext="<%= application %>">
-											<liferay-util:param name="searchContainerId" value="versions" />
-											<liferay-util:param name="showEditActions" value="false" />
-										</liferay-util:include>
-									</liferay-ui:section>
-								</c:if>
+							<c:if test='<%= Objects.equals(journalDisplayContext.getTabs1(), "web-content") %>'>
+								<liferay-util:include page="/view_entries.jsp" servletContext="<%= application %>">
+									<liferay-util:param name="searchContainerId" value="articles" />
+								</liferay-util:include>
+							</c:if>
 
-								<c:if test="<%= journalDisplayContext.hasCommentsResults() %>">
-									<liferay-ui:section>
-										<liferay-util:include page="/view_comments.jsp" servletContext="<%= application %>">
-											<liferay-util:param name="searchContainerId" value="comments" />
-										</liferay-util:include>
-									</liferay-ui:section>
-								</c:if>
-							</liferay-ui:tabs>
+							<c:if test='<%= Objects.equals(journalDisplayContext.getTabs1(), "versions") %>'>
+								<liferay-util:include page="/view_versions.jsp" servletContext="<%= application %>">
+									<liferay-util:param name="searchContainerId" value="versions" />
+									<liferay-util:param name="showEditActions" value="false" />
+								</liferay-util:include>
+							</c:if>
+
+							<c:if test='<%= Objects.equals(journalDisplayContext.getTabs1(), "comments") %>'>
+								<liferay-util:include page="/view_comments.jsp" servletContext="<%= application %>">
+									<liferay-util:param name="searchContainerId" value="comments" />
+								</liferay-util:include>
+							</c:if>
 						</c:otherwise>
 					</c:choose>
 				</div>

--- a/journal-web/src/main/resources/META-INF/resources/view.jsp
+++ b/journal-web/src/main/resources/META-INF/resources/view.jsp
@@ -103,29 +103,34 @@ data.put("qa-id", "navigation");
 
 							<%
 							String[] tabsNames = new String[0];
+							String[] tabsValues = new String[0];
 
 							if (journalDisplayContext.hasResults()) {
 								String tabName = StringUtil.appendParentheticalSuffix(LanguageUtil.get(request, "web-content"), journalDisplayContext.getTotal());
 
 								tabsNames = ArrayUtil.append(tabsNames, tabName);
+								tabsValues = ArrayUtil.append(tabsValues, "web-content");
 							}
 
 							if (journalDisplayContext.hasVersionsResults()) {
 								String tabName = StringUtil.appendParentheticalSuffix(LanguageUtil.get(request, "versions"), journalDisplayContext.getVersionsTotal());
 
 								tabsNames = ArrayUtil.append(tabsNames, tabName);
+								tabsValues = ArrayUtil.append(tabsValues, "versions");
 							}
 
 							if (journalDisplayContext.hasCommentsResults()) {
 								String tabName = StringUtil.appendParentheticalSuffix(LanguageUtil.get(request, "comments"), journalDisplayContext.getCommentsTotal());
 
 								tabsNames = ArrayUtil.append(tabsNames, tabName);
+								tabsValues = ArrayUtil.append(tabsValues, "comments");
 							}
 							%>
 
 							<liferay-ui:tabs
 								names="<%= StringUtil.merge(tabsNames) %>"
 								portletURL="<%= portletURL %>"
+								tabsValues="<%= StringUtil.merge(tabsValues) %>"
 								type="tabs nav-tabs-default"
 							>
 								<c:if test="<%= journalDisplayContext.hasResults() %>">

--- a/journal-web/src/main/resources/META-INF/resources/view.jsp
+++ b/journal-web/src/main/resources/META-INF/resources/view.jsp
@@ -134,24 +134,29 @@ data.put("qa-id", "navigation");
 								type="tabs nav-tabs-default"
 							/>
 
-							<c:if test='<%= Objects.equals(journalDisplayContext.getTabs1(), "web-content") %>'>
-								<liferay-util:include page="/view_entries.jsp" servletContext="<%= application %>">
-									<liferay-util:param name="searchContainerId" value="articles" />
-								</liferay-util:include>
-							</c:if>
-
-							<c:if test='<%= Objects.equals(journalDisplayContext.getTabs1(), "versions") %>'>
-								<liferay-util:include page="/view_versions.jsp" servletContext="<%= application %>">
-									<liferay-util:param name="searchContainerId" value="versions" />
-									<liferay-util:param name="showEditActions" value="false" />
-								</liferay-util:include>
-							</c:if>
-
-							<c:if test='<%= Objects.equals(journalDisplayContext.getTabs1(), "comments") %>'>
-								<liferay-util:include page="/view_comments.jsp" servletContext="<%= application %>">
-									<liferay-util:param name="searchContainerId" value="comments" />
-								</liferay-util:include>
-							</c:if>
+							<c:choose>
+								<c:when test='<%= Objects.equals(journalDisplayContext.getTabs1(), "web-content") || (journalDisplayContext.hasResults() && Validator.isNull(journalDisplayContext.getTabs1())) %>'>
+									<liferay-util:include page="/view_entries.jsp" servletContext="<%= application %>">
+										<liferay-util:param name="searchContainerId" value="articles" />
+									</liferay-util:include>
+								</c:when>
+								<c:when test='<%= Objects.equals(journalDisplayContext.getTabs1(), "versions") || (journalDisplayContext.hasVersionsResults() && Validator.isNull(journalDisplayContext.getTabs1())) %>'>
+									<liferay-util:include page="/view_versions.jsp" servletContext="<%= application %>">
+										<liferay-util:param name="searchContainerId" value="versions" />
+										<liferay-util:param name="showEditActions" value="false" />
+									</liferay-util:include>
+								</c:when>
+								<c:when test='<%= Objects.equals(journalDisplayContext.getTabs1(), "comments") || (journalDisplayContext.hasCommentsResults() && Validator.isNull(journalDisplayContext.getTabs1())) %>'>
+									<liferay-util:include page="/view_comments.jsp" servletContext="<%= application %>">
+										<liferay-util:param name="searchContainerId" value="comments" />
+									</liferay-util:include>
+								</c:when>
+								<c:otherwise>
+									<liferay-util:include page="/view_entries.jsp" servletContext="<%= application %>">
+										<liferay-util:param name="searchContainerId" value="articles" />
+									</liferay-util:include>
+								</c:otherwise>
+							</c:choose>
 						</c:otherwise>
 					</c:choose>
 				</div>

--- a/journal-web/src/main/resources/META-INF/resources/view.jsp
+++ b/journal-web/src/main/resources/META-INF/resources/view.jsp
@@ -94,7 +94,7 @@ data.put("qa-id", "navigation");
 
 				<div class="journal-container" id="<portlet:namespace />entriesContainer">
 					<c:choose>
-						<c:when test="<%= !journalDisplayContext.isSearch() || (!journalDisplayContext.hasResults() && !journalDisplayContext.hasCommentsResults()) %>">
+						<c:when test="<%= !journalDisplayContext.isSearch() || (!journalDisplayContext.hasResults() && !journalDisplayContext.hasCommentsResults() && !journalDisplayContext.hasVersionsResults()) %>">
 							<liferay-util:include page="/view_entries.jsp" servletContext="<%= application %>">
 								<liferay-util:param name="searchContainerId" value="articles" />
 							</liferay-util:include>

--- a/test.properties
+++ b/test.properties
@@ -14,5 +14,11 @@
 		subrepository-integration-mysql56-jdk8
 
 	test.batch.run.property.query[subrepository-functional-tomcat80-mysql56-jdk8]=\
-		(portal.acceptance == "true") AND \
-		(testray.main.component.name ~ "Web Content")
+	(\
+		(portal.acceptance == true) OR \
+		(testray.main.component.name ~ "Upgrades")\
+	) AND \
+	(\
+		(testray.component.names ~ "Web Content") OR \
+		(testray.main.component.name ~ "Web Content")\
+	)


### PR DESCRIPTION
Relevant tickets:
https://issues.liferay.com/browse/LPP-24514
https://issues.liferay.com/browse/LPS-71907
https://issues.liferay.com/browse/LPS-71050 (depends on new API from this ticket)

This is largely a revised re-send from https://github.com/jonathanmccann/com-liferay-journal/pull/12, but I figured since it depends on changes from the already resolved [LPS-71050](https://issues.liferay.com/browse/LPS-71050), it would be best to open LPS-71907 as a new LPS. It's also been quite a while since that pull request was closed.

LPS-71050 adds API to portal-kernel to allow PortletDataHandlers to disable the "Mirror with overwriting" import strategy option if it's not implemented. This pull leverages this to disable the option, since even if it will be implemented at some point, for now it is not; if it's implemented, then this can simply be changed back to return "true," re-enabling the strategy. We are targeting this use case (Web Content imports) for a customer-specific issue.