### PR TITLE
LPS-74910 calculate selectedGroupIds after request

### DIFF
--- a/journal-content-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/journal-content-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -69,7 +69,9 @@ String redirect = ParamUtil.getString(request, "redirect");
 			PortletURL selectWebContentURL = PortletProviderUtil.getPortletURL(request, JournalArticle.class.getName(), PortletProvider.Action.BROWSE);
 
 			selectWebContentURL.setParameter("groupId", String.valueOf(journalContentDisplayContext.getGroupId()));
-			selectWebContentURL.setParameter("selectedGroupIds", StringUtil.merge(journalContentDisplayContext.getSelectedGroupIds()));
+			selectWebContentURL.setParameter("sharedContentCompanyId", String.valueOf(themeDisplay.getCompanyId()));
+			selectWebContentURL.setParameter("sharedContentSiteGroupId", String.valueOf(themeDisplay.getScopeGroupId()));
+			selectWebContentURL.setParameter("sharedContentUserId", String.valueOf(themeDisplay.getUserId()));
 			selectWebContentURL.setParameter("refererAssetEntryId", "[$ARTICLE_REFERER_ASSET_ENTRY_ID$]");
 			selectWebContentURL.setParameter("typeSelection", JournalArticle.class.getName());
 			selectWebContentURL.setParameter("showNonindexable", String.valueOf(Boolean.TRUE));


### PR DESCRIPTION
Linked with PR https://github.com/SamZiemer/com-liferay-asset/pull/1

https://issues.liferay.com/browse/LPS-74910

Instead of passing selectedGroupIds in the request (giving a 414 error) we pass companyId, groupId, userId to be used to calculate selectedGroupIds outside the request.